### PR TITLE
Feature/mmt 1507

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -101,7 +101,7 @@ class CollectionsController < ApplicationController
       rescue => ex
         Rails.logger.error
         ("PyCMR Error: Unknown error ingesting Revision #{params[:revision_id]} with Concept ID #{params[:concept_id]} with error\n#{ex.backtrace}")
-        flash[:alert] = 'There was an error ingesting the record into the system'
+        flash[:alert] = "There was an error ingesting the record into the system #{ex.message}"
       end
     end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -95,8 +95,12 @@ class CollectionsController < ApplicationController
         flash[:alert] = 'There was a read timeout error connecting to the CMR System, please try again'
       rescue Timeout::Error
         flash[:alert] = 'The pyCMR script timed out and the collection was unable to be ingested'
+      rescue Errors::PythonError
+        ("PyCMR Error: Unknown error ingesting Revision #{params[:revision_id]} with Concept ID #{params[:concept_id]} with error")
+        flash[:alert] = 'There was an python error checking metadata'
       rescue => ex
-        Rails.logger.error("PyCMR Error: Unknown error ingesting Revision #{params[:revision_id]} with Concept ID #{params[:concept_id]} with error\n#{ex.backtrace}")
+        Rails.logger.error
+        ("PyCMR Error: Unknown error ingesting Revision #{params[:revision_id]} with Concept ID #{params[:concept_id]} with error\n#{ex.backtrace}")
         flash[:alert] = 'There was an error ingesting the record into the system'
       end
     end

--- a/app/errors/errors.rb
+++ b/app/errors/errors.rb
@@ -1,0 +1,3 @@
+class Errors
+  class PythonError < StandardError; end
+end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -59,7 +59,7 @@ class Collection < ActiveRecord::Base
 
       # In production there is an egress issue with certain link types given in metadata
       # AWS hangs requests that break ingress/egress rules.  Added this timeout to catch those
-      Timeout::timeout(20) { new_record.create_script } if options[:run_script]
+      Timeout::timeout(40) { new_record.create_script } if options[:run_script]
 
       collection.add_granule(user) if options[:add_granule]
 

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,3 +1,3 @@
-class Errors
+module Errors
   class PythonError < StandardError; end
 end

--- a/app/models/record_formats/dif10_record.rb
+++ b/app/models/record_formats/dif10_record.rb
@@ -60,23 +60,30 @@ module RecordFormats
       if raw_data.nil?
         raw_data = get_raw_data
       end
+      raw_data.each { |key, value|
+        if value.instance_of? String
+          value.gsub!('"', '')
+        end
+      }
       #escaping json for passing to python
-      record_json = raw_data.to_json.gsub("\"", "\\\"")
+      # https://stackoverflow.com/questions/28356308/escaping-single-quotes-for-shell
+      record_json = raw_data.to_json
+      record_json.gsub!("'", "'\\\\''")
       #running collection script in python
       #W option to silence warnings
       if collection?
-        script_results = `python -W ignore lib/CollectionCheckerDIF.py "#{record_json}"  `
+        script_results = `python -W ignore lib/CollectionCheckerDIF.py '#{record_json}'  `
       else
         script_results = nil
       end
 
-      unless script_results.nil?
+      unless script_results.to_s.empty?
         comment_hash = JSON.parse(script_results)
         value_keys = self.record_datas.map { |data| data.column_name }
         comment_hash = Record.format_script_comments(comment_hash, value_keys)
         comment_hash
       else
-        {}
+        raise Errors::PythonError
       end
     end
 

--- a/app/models/record_formats/echo10_record.rb
+++ b/app/models/record_formats/echo10_record.rb
@@ -99,7 +99,7 @@ module RecordFormats
         comment_hash = Record.format_script_comments(comment_hash, value_keys)
         comment_hash
       else
-        raise PythonError
+        raise Errors::PythonError
       end
     end
 

--- a/app/models/record_formats/echo10_record.rb
+++ b/app/models/record_formats/echo10_record.rb
@@ -73,23 +73,33 @@ module RecordFormats
       if raw_data.nil?
         raw_data = get_raw_data
       end
+      raw_data.each { |key, value|
+        if value.instance_of? String
+          value.gsub!('"', '')
+        end
+      }
+
       #escaping json for passing to python
-      record_json = raw_data.to_json.gsub("\"", "\\\"")
+      # https://stackoverflow.com/questions/28356308/escaping-single-quotes-for-shell
+      record_json = raw_data.to_json
+      record_json.gsub!("'", "'\\\\''")
+
       #running collection script in python
       #W option to silence warnings
       if collection?
-        script_results = `python -W ignore lib/CollectionChecker.py "#{record_json}"  `
+        script_results = `python -W ignore lib/CollectionChecker.py '#{record_json}'  `
       else
-        script_results = `python -W ignore lib/GranuleChecker.py "#{record_json}"`
+        script_results = `python -W ignore lib/GranuleChecker.py '#{record_json}'`
       end
 
-      unless script_results.nil?
+
+      unless script_results.to_s.empty?
         comment_hash = JSON.parse(script_results)
         value_keys = self.record_datas.map { |data| data.column_name }
         comment_hash = Record.format_script_comments(comment_hash, value_keys)
         comment_hash
       else
-        {}
+        raise PythonError
       end
     end
 


### PR DESCRIPTION
Couple issues.
1) I had to increase the timeout as the validation checker was taking longer in some cases.
2) The ruby method was not raising any errors if the script returned nil or empty, so I modified that and created a custom error, need feedback in how I did this. There are still some records that won't load, but that is due to something wrong in the python script, but atleast it states that now, rather than just a general error (I'll provide a list of records that still won't load and they'll need to modify their python scripts.
3) The way the script is called, it passes the entire json metadata to python script.   The argument is passed in double quotes "", but if there are double  anywhere in the json field values, that would cause issues parsing the json.   So I stripped out the "" from appearing in any field values, maybe a better way is to escape?   
4) Finally, there was still issues passing the json in double quotes and escaping the double quote " used in the json (which is how it was done here), so I modified it to pass the json in single quotes and escaped the occasional single quote that may appear in the json.   This seemed to fix the issues with the other set of records not loading.