### PR TITLE
MMT-1482 - downgraded font-awesome-sass from 5.0.13 to 5.0.9 it had a…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,7 @@ gem 'aws-sdk', '~> 2.2.37'
 #store env vars in the .env file
 gem 'dotenv-rails', '~> 2.1.1'
 
-gem 'font-awesome-sass'
+gem 'font-awesome-sass', '5.0.9'
 
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ gem 'aws-sdk', '~> 2.2.37'
 #store env vars in the .env file
 gem 'dotenv-rails', '~> 2.1.1'
 
+# Should use 5.0.13 but compatibility issues with SIT version of RH, has older GCC.    Eventualaly when they upgrade RH, we can move back to the latest
 gem 'font-awesome-sass', '5.0.9'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,8 +80,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.25)
-    font-awesome-sass (5.0.13)
-      sassc (>= 1.11)
+    font-awesome-sass (5.0.9)
+      sass (>= 3.2)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashdiff (0.3.7)
@@ -186,9 +186,6 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (1.12.1)
-      ffi (~> 1.9.6)
-      sass (>= 3.3.0)
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
@@ -240,7 +237,7 @@ DEPENDENCIES
   devise
   dotenv-rails (~> 2.1.1)
   execjs (~> 2.7.0)
-  font-awesome-sass
+  font-awesome-sass (= 5.0.9)
   httparty (~> 0.14.0)
   jbuilder (~> 2.0)
   jquery-rails


### PR DESCRIPTION
downgraded font-awesome-sass from 5.0.13 to 5.0.9 it had a depency that breaks when deployed to SIT environment (sassc), this version uses sass which seems to work.   I think one of these libraries are deprecated so we will need to eventually get off this, but first Redhat systems need to be upgraded to support this, as gcc version is old.