### PR TITLE
Feature/mmt 1509

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,10 @@
 
 # Ignore test reports
 test/reports/*
+
+# Rubymine
+.idea
+*.iml
+
+# Backup files
+*~

--- a/app/controllers/granules_controller.rb
+++ b/app/controllers/granules_controller.rb
@@ -7,20 +7,28 @@ class GranulesController < ApplicationController
   end
 
   def replace
-    granule    = Granule.find(params[:id])
-    record     = granule.records.find(params[:record_id])
+    granule = Granule.find(params[:id])
+    record = granule.records.find(params[:record_id])
     collection = granule.collection
 
     authorize! :replace_granule, granule
 
-    if record.open?
-      granule.destroy
-      collection.add_granule(current_user)
+    # Removing temporarily until we come up with a process flow that allows them to reopen the record after it has
+    # been closed.   A new ticket should be created allowing them to reopen a record.
 
-      flash[:notice] = "A new granule has been selected for this collection"
-    else
-      flash[:alert] = "This granule is in review, and can no longer be changed to a different granule"
-    end
+    # if record.open?
+    #   granule.destroy
+    #   collection.add_granule(current_user)
+    #
+    #   flash[:notice] = "A new granule has been selected for this collection"
+    # else
+    #   flash[:alert] = "This granule is in review, and can no longer be changed to a different granule"
+    # end
+    #
+
+    granule.destroy
+    collection.add_granule(current_user)
+    flash[:notice] = "A new granule has been selected for this collection"
 
     redirect_to collection_path(id: 1, record_id: collection.records.first.id)
   end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -105,7 +105,7 @@
                       </div>
 
                       <div>
-                        <% can?(:replace_granule, granule_record.recordable) %>
+                        <% if can?(:replace_granule, granule_record.recordable) %>
                           <%= button_to "Ingest Different Granule", replace_granule_path(granule_record.recordable_id, record_id: granule_record.id), method: :delete, class: "smallSelectButton", id: "ingest_replace", data: { confirm: "Are you sure?" } %>
                         <% end %>
                       </div>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -105,7 +105,7 @@
                       </div>
 
                       <div>
-                        <% if granule_record.open? && can?(:replace_granule, granule_record.recordable) %>
+                        <% can?(:replace_granule, granule_record.recordable) %>
                           <%= button_to "Ingest Different Granule", replace_granule_path(granule_record.recordable_id, record_id: granule_record.id), method: :delete, class: "smallSelectButton", id: "ingest_replace", data: { confirm: "Are you sure?" } %>
                         <% end %>
                       </div>

--- a/test/controllers/granules_controller_test.rb
+++ b/test/controllers/granules_controller_test.rb
@@ -15,19 +15,23 @@ class GranulesControllerTest < ActionController::TestCase
       assert_equal "You are not authorized to access this page.", flash[:alert]
     end
 
-    it "prevents replacement on Granules in review" do
-      user = User.find_by role: "admin"
-      sign_in(user)
 
-      granule = Granule.first
-      record  = granule.records.find(5)
-      collection = granule.collection
-
-      delete :replace, id: granule.id, record_id: record.id
-
-      assert_redirected_to collection_path(id: 1, record_id: collection.records.first.id)
-      assert_equal "This granule is in review, and can no longer be changed to a different granule", flash[:alert]
-    end
+    # Removed this test until a better workflow is designed, right now you can't reopen a record, to allow you to
+    # ingest it.
+    #
+    # it "prevents replacement on Granules in review" do
+    #   user = User.find_by role: "admin"
+    #   sign_in(user)
+    #
+    #   granule = Granule.first
+    #   record  = granule.records.find(5)
+    #   collection = granule.collection
+    #
+    #   delete :replace, id: granule.id, record_id: record.id
+    #
+    #   assert_redirected_to collection_path(id: 1, record_id: collection.records.first.id)
+    #   assert_equal "This granule is in review, and can no longer be changed to a different granule", flash[:alert]
+    # end
 
     it "will delete and replace the granule" do
       user = User.find_by role: "admin"


### PR DESCRIPTION
This fix always keeps the “ingest new granule” button appearing.   arcteam told us this ia a critical feature that needs to be pushed to production.