### PR TITLE
Removed dashboard routes that have extension

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,16 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   # http_basic_authenticate_with name: "cmruser", password: "dashpass"
 
+  rescue_from ActionController::RoutingError, :with => :render_404
+  private
+  def render_404(exception = nil)
+    if exception
+      logger.info "Rendering 404: #{exception.message}"
+    end
+
+    render :file => "#{Rails.root}/public/404.html", :status => 404, :layout => false
+  end
+
 
   #saving error from CanCan for users going beyond allowed pages
   rescue_from CanCan::AccessDenied do |exception|

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,6 @@
+class ErrorsController < ApplicationController
+  # https://stackoverflow.com/questions/21654826/how-to-rescue-page-not-found-404-in-rails
+  def routing
+    render_404
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,59 +1,65 @@
 Rails.application.routes.draw do
-  get '/elb_status', to: 'site#elb_status'
+  scope format: false do
+    get '/elb_status', to: 'site#elb_status'
 
-  devise_for :users, controllers: {
-    registrations: 'users/registrations'
-  }
+    devise_for :users, controllers: {
+        registrations: 'users/registrations'
+    }
 
-  devise_scope :user do
-    root to: "devise/sessions#new"
-    get '/users/sign_out', to: 'users/sessions#destroy'
-  end
-
-  get '/home', to: 'site#home'
-  get '/general_home', to: 'site#general_home'
-
-  resources :collections do
-    collection do
-      put 'refresh'
-    end
-  end
-
-  get '/collections_search', to: 'collections#search'
-
-  resources :granules do
-    member do
-      delete "replace"
-    end
-  end
-  resources :comments
-  resources :reviews
-  resources :records do
-    member do
-      post "complete"
+    devise_scope :user do
+      root to: "devise/sessions#new"
+      get '/users/sign_out', to: 'users/sessions#destroy'
     end
 
-    collection do
-      get "finished"
-      get "navigate"
-      put "allow_updates"
-      put "stop_updates"
-      post "batch_complete"
-      delete "hide"
+    get '/home', to: 'site#home'
+    get '/general_home', to: 'site#general_home'
+
+    resources :collections do
+      collection do
+        put 'refresh'
+      end
     end
+
+    get '/collections_search', to: 'collections#search'
+
+    resources :granules do
+      member do
+        delete "replace"
+      end
+    end
+    resources :comments
+    resources :reviews
+    resources :records do
+      member do
+        post "complete"
+      end
+
+      collection do
+        get "finished"
+        get "navigate"
+        put "allow_updates"
+        put "stop_updates"
+        post "batch_complete"
+        delete "hide"
+      end
+    end
+
+    get '/record_refresh', to: 'records#refresh'
+
+    get '/reports/home', to: 'reports#home'
+    get '/reports/provider', to: 'reports#provider'
+    get '/reports/search', to: 'reports#search'
+    get '/reports/selection', to: 'reports#selection'
+    get '/reports/review', to: 'reports#review'
+
+    #making a convenient path to the rdoc files
+    if ENV['SHOW_DOCUMENTATION'] == 'true'
+      get "/documentation" => redirect("/doc/index.html")
+    end
+
+    # https://stackoverflow.com/questions/21654826/how-to-rescue-page-not-found-404-in-rails
+    # The “a” is actually a parameter in the Rails 3 Route Globbing technique. For example,
+    # if your url was /this-url-does-not-exist, then params[:a] equals “/this-url-does-not-exist”.
+    match '*a', :to => 'errors#routing', via: :get
   end
-
-  get '/record_refresh', to: 'records#refresh'
-
-  get '/reports/home', to: 'reports#home'
-  get '/reports/provider', to: 'reports#provider'
-  get '/reports/search', to: 'reports#search'
-  get '/reports/selection', to: 'reports#selection'
-  get '/reports/review', to: 'reports#review'
-
-  #making a convenient path to the rdoc files
-  if ENV['SHOW_DOCUMENTATION'] == 'true'
-    get "/documentation" => redirect("/doc/index.html")
-  end
-
 end


### PR DESCRIPTION
Removed dashboard routes that include extensions (.bk, .1, etc) and sending all bad routing calls to 404 page.