### PR TITLE
MMT-1473 - removed rescue_from routing error which no longer works in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,7 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
-  # http_basic_authenticate_with name: "cmruser", password: "dashpass"
 
-  rescue_from ActionController::RoutingError, :with => :render_404
   private
   def render_404(exception = nil)
     if exception


### PR DESCRIPTION
removed rescue_from routing error which no longer works in later version of rails.