### PR TITLE
Feature/cmrarc 390 (#33)

### DIFF
--- a/app/mailers/curator_mailer.rb
+++ b/app/mailers/curator_mailer.rb
@@ -2,7 +2,6 @@ class CuratorMailer < ActionMailer::Base
 
   def released_records(users, records)
     @records = records
-
     mail(from: ENV['MAILER_SENDER'], to: users.map(&:email), subject: 'Metadata Curation Tool Released Records')
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,7 +18,7 @@ Rails.application.configure do
 
   #config.action_mailer.delivery_method = :file
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  # config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.smtp_settings = {
     address: ENV['MAILER_SMTP_HOST'],
     user_name: ENV['MAILER_SMTP_USER'],
@@ -27,6 +27,7 @@ Rails.application.configure do
     enable_starttls_auto: true,
     port: 587
   }
+
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,15 +64,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
-  #config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
-  config.action_mailer.smtp_settings = {
-    address: ENV['MAILER_SMTP_HOST'],
-    user_name: ENV['MAILER_SMTP_USER'],
-    password: ENV['MAILER_SMTP_PASSWORD'],
-    authentication: :login,
-    enable_starttls_auto: true,
-    port: 587
-  }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
* CMRARC-390 The significant change here was in production.rb, it should not use the ENV settings for smtp configuration. Rather letting it default to localhost settings for smtp server seems to work (I tested this in SIT using these settings).