### PR TITLE
CMRARC-393 updated rubyzip to 1.2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,6 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-
   gem 'rdoc'
+  gem 'rubyzip', '1.2.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
     rubyXL (3.3.29)
       nokogiri (>= 1.4.4)
       rubyzip (>= 1.1.6)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
@@ -265,6 +265,7 @@ DEPENDENCIES
   rdoc
   ruby-progressbar
   rubyXL
+  rubyzip (= 1.2.2)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov


### PR DESCRIPTION
github complaining about rubyzip gem 1.2.1 and recommends 1.2.2