### PR TITLE
Removed configuration value to not perform mail deliveries 

### DIFF
--- a/app/mailers/curator_mailer.rb
+++ b/app/mailers/curator_mailer.rb
@@ -2,13 +2,12 @@ class CuratorMailer < ActionMailer::Base
 
   def released_records(users, records)
     @records = records
-    mail(from: ENV['MAILER_SENDER'], to: users.map(&:email), subject: 'Metadata Curation Tool Released Records')
+    #mail(from: ENV['MAILER_SENDER'], to: users.map(&:email), subject: 'Metadata Curation Tool Released Records')
   end
 
   def closed_records(users, records)
     @records = records
-
-    mail(from: ENV['MAILER_SENDER'], to: users.map(&:email), subject: 'Metadata Curation Tool Closed Records')
+    #mail(from: ENV['MAILER_SENDER'], to: users.map(&:email), subject: 'Metadata Curation Tool Closed Records')
   end
 
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.perform_deliveries = false
 
   #config.action_mailer.delivery_method = :file
   config.action_mailer.delivery_method = :smtp

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = false
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
Note this is a pull request into master since it is a hot fix.   
Removed configuration value to not perform mail deliveries and just to be sure commented out the code in the mailer class that actually performs the mailing.