### PR TITLE
CMRARC-418 - Testing revealed a few issues.  1) If the user is a

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://git.earthdata.nasa.gov/scm/cmrarc/omniauth-urs.git
-  revision: 65ec1946755e2593f1bb1308a4d637818a0ec890
+  revision: be1bb964c5fec43628b4a9e5bf8772b4edf64469
   branch: develop
   specs:
     omniauth-urs (0.1.0)
@@ -127,8 +127,6 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.6)
     jwt (2.1.0)
-      crass (~> 1.0.2)
-      nokogiri (>= 1.5.9)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -9,13 +9,13 @@ class LoginController < Devise::OmniauthCallbacksController
     # don't the role will be nil.
     if @user.persisted? && !@user.role.nil?
       sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
-      set_flash_message(:notice, :success, kind: "Earth Data Login") if is_navigational_format?
+      set_flash_message(:notice, :success, kind: "Earthdata Login") if is_navigational_format?
     else
       redirect_to root_path
       if (@user.role.nil?)
-        flash.notice = "User is not provisioned with the proper ACLs.   Please contact the Operations team."
+        flash.notice = "User is not provisioned with the proper ACLs.   Please contact the Earthdata Operations team."
       else
-        flash.notice = "Could not authenticate from Earth Data Login"
+        flash.notice = "Could not authenticate from Earthdata Login"
       end
     end
   end

--- a/app/models/acl_dao.rb
+++ b/app/models/acl_dao.rb
@@ -7,7 +7,8 @@ class AclDao
     @base_url = base_url
   end
 
-  def get_role(user_id)
+  # returns [role, daac_name]
+  def get_role_and_daac(user_id)
 
     # Sets whether the user is a specific role type
     # Note: user could be all three.
@@ -22,8 +23,14 @@ class AclDao
     end
 
     roles = Set.new
+
+    # this logic assumes that a user can only belong to 1 daac, which is the case with dashboard.
+    daac = nil
     items.each do |item|
-      roles << "daac_curator" if item['name'].end_with?"DASHBOARD_DAAC_CURATOR"
+      if item['name'].end_with?"DASHBOARD_DAAC_CURATOR"
+        daac = item['name'].match(/(.*)\-(.*)-(.*)/)[2].strip
+        roles << "daac_curator"
+      end
       roles << "arc_curator" if item['name'].end_with?"DASHBOARD_ARC_CURATOR"
       roles << "admin" if item['name'].end_with?"DASHBOARD_ADMIN"
     end
@@ -31,9 +38,9 @@ class AclDao
     #
     # returns the highest level role
     #
-    return "admin" if roles.include? "admin"
-    return "daac_curator" if roles.include? "daac_curator"
-    return "arc_curator" if roles.include? "arc_curator"
+    return ["admin", nil] if roles.include? "admin"
+    return ["daac_curator",daac] if roles.include? "daac_curator"
+    return ["arc_curator", nil] if roles.include? "arc_curator"
 
     nil
   end

--- a/app/models/acl_dao.rb
+++ b/app/models/acl_dao.rb
@@ -28,8 +28,18 @@ class AclDao
     daac = nil
     items.each do |item|
       if item['name'].end_with?"DASHBOARD_DAAC_CURATOR"
-        daac = item['name'].match(/(.*)\-(.*)-(.*)/)[2].strip
+
+        if daac
+          # there is already daac assigned, this means CMR OPS team has provisioned a user with more than 1 DAAC
+          # so we should mentioned something in the logs.
+          Rails.logger.error("Error: User #{user_id} is already provisioned with a DAAC (#{daac})")
+        end
+
+        location = item['location']
+        acl = send_request_to_cmr :GET, location, nil
+        daac = acl['provider_identity']['provider_id']
         roles << "daac_curator"
+
       end
       roles << "arc_curator" if item['name'].end_with?"DASHBOARD_ARC_CURATOR"
       roles << "admin" if item['name'].end_with?"DASHBOARD_ADMIN"

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -622,10 +622,11 @@ class Cmr
     cmr_base_url
   end
 
-  def self.getRole(uid, access_token)
+  # returns [role, daac_name]
+  def self.get_role_and_daac(uid, access_token)
     acl = AclDao.new(access_token, ENV['urs_client_id'], Cmr.get_cmr_base_url)
-    role = acl.get_role(uid)
-    role
+    role, daac = acl.get_role_and_daac(uid)
+    [role, daac]
   end
 
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,14 +15,15 @@ class User < ActiveRecord::Base
     if !user
       user = User.new
       user.uid = auth.uid
-      user.role = Cmr.getRole(auth.uid, auth.credentials["access_token"]);
       user.provider = auth.provider # this is omniauth provider type, i.e., value=URS
-      user.email = auth.info.email_address
-      user.save
-    else
-      user.role = Cmr.getRole(auth.uid, auth.credentials["access_token"]);
-      user.save
     end
+    user.email = auth.info.email_address
+    role, daac = Cmr.get_role_and_daac(auth.uid, auth.credentials["access_token"])
+    user.role = role
+    if daac and daac.length != 0
+      user.daac = daac
+    end
+    user.save!
     user
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,9 +20,7 @@ class User < ActiveRecord::Base
     user.email = auth.info.email_address
     role, daac = Cmr.get_role_and_daac(auth.uid, auth.credentials["access_token"])
     user.role = role
-    if daac and daac.length != 0
-      user.daac = daac
-    end
+    user.daac = daac if daac
     user.save!
     user
   end

--- a/test/features/can_access_top_page_test.rb
+++ b/test/features/can_access_top_page_test.rb
@@ -43,6 +43,13 @@ class CanAccessTopPageTest < Capybara::Rails::TestCase
         page.must_have_content("Logout")
         page.must_have_content("Account Options")
         page.must_have_content("Unreviewed Records:")
+        page.must_have_content("In ARC Review Records:")
+        page.must_have_content("Awaiting Release to DAAC:")
+        page.must_have_content("In DAAC Review:")
+        page.must_have_content("Requires Curator Feedback Records:")
+
+
+
       end
 
       it "can sign in user with oauth account with arc curator privileges" do
@@ -64,11 +71,25 @@ class CanAccessTopPageTest < Capybara::Rails::TestCase
         page.must_have_content("Logout")
         page.wont_have_content("Account Options")
         page.must_have_content("Unreviewed Records:")
+        page.must_have_content("In ARC Review Records:")
+        page.must_have_content("Awaiting Release to DAAC:")
+        page.wont_have_content("In DAAC Review:")
+        page.must_have_content("Requires Curator Feedback Records:")
 
       end
 
       it "can sign in user with oauth account with daac curator privileges" do
         mock_auth_hash
+
+        stub_request(:get, "https://cmr.sit.earthdata.nasa.gov/access-control/acls/ACL1200303063-CMR").
+          with(
+            headers: {
+              'Accept'=>'*/*',
+              'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Echo-Token'=>'12345:',
+              'User-Agent'=>'Faraday v0.15.3'
+            }).
+          to_return(status: 200, body: '{"group_permissions":[{"group_id":"AG1200303062-LARC","permissions":["create"]},{"group_id":"AG1200301542-CMR","permissions":["create"]},{"group_id":"AG1200303012-CMR","permissions":["create"]}],"provider_identity":{"target":"DASHBOARD_DAAC_CURATOR","provider_id":"LARC"}}', headers: {})
 
         stub_request(:get, "#{Cmr.get_cmr_base_url}/access-control/acls?page_num=1&page_size=2000&permitted_user=12345").
           with(
@@ -83,13 +104,11 @@ class CanAccessTopPageTest < Capybara::Rails::TestCase
         page.must_have_content("Login with Earthdata Login")
         click_link "Login"
         page.must_have_content("Logout")
+        page.must_have_content("In DAAC Review:")
+        page.must_have_content("Requires Curator Feedback Records:")
         page.wont_have_content("Unreviewed Records:")
       end
-
-
-
-
-
+      
       it "can handle authentication error" do
         OmniAuth.config.mock_auth[:urs] = :invalid_credentials
         visit '/'

--- a/test/features/can_access_top_page_test.rb
+++ b/test/features/can_access_top_page_test.rb
@@ -42,6 +42,7 @@ class CanAccessTopPageTest < Capybara::Rails::TestCase
         click_link "Login"
         page.must_have_content("Logout")
         page.must_have_content("Account Options")
+        page.must_have_content("Unreviewed Records:")
       end
 
       it "can sign in user with oauth account with arc curator privileges" do
@@ -62,7 +63,31 @@ class CanAccessTopPageTest < Capybara::Rails::TestCase
         click_link "Login"
         page.must_have_content("Logout")
         page.wont_have_content("Account Options")
+        page.must_have_content("Unreviewed Records:")
+
       end
+
+      it "can sign in user with oauth account with daac curator privileges" do
+        mock_auth_hash
+
+        stub_request(:get, "#{Cmr.get_cmr_base_url}/access-control/acls?page_num=1&page_size=2000&permitted_user=12345").
+          with(
+            headers: {
+              'Accept'=>'*/*',
+              'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Echo-Token'=>'12345:',
+              'User-Agent'=>'Faraday v0.15.3'
+            }).
+          to_return(status: 200, body: '{"hits":1,"took":661,"items":[{"revision_id":3,"concept_id":"ACL1200303063-CMR","identity_type":"Provider","name":"Provider - LARC - DASHBOARD_DAAC_CURATOR","location":"'+Cmr.get_cmr_base_url+':443/access-control/acls/ACL1200303063-CMR"}]}', headers: {})
+        visit '/'
+        page.must_have_content("Login with Earthdata Login")
+        click_link "Login"
+        page.must_have_content("Logout")
+        page.wont_have_content("Unreviewed Records:")
+      end
+
+
+
 
 
       it "can handle authentication error" do


### PR DESCRIPTION
Testing revealed a few issues.  1) If the user is a
daac_curator, an associated daac should be assigned.  Modified the
ACL code to retrieve the daac associated with the daac curator and both are
now assigned to the user.   Note it uses the provider as the daac.

2) Added tests for pulling in daac curators.   Also if it is a daac
added a test to make sure by checking the page you log into, daac curators
don't have a section called "Unreviewed" only arc curators and admins.
Tested for this for their use cases as well.

3) omniauth-urs code was updated in the developer branch and for the gem was being cached, so had to rebuild by clearing the cache on the build machine.