### PR TITLE
CMRARC-419 prevents a KeyError by calling .get() instead of redirecti…

### DIFF
--- a/lib/CheckerGranule.py
+++ b/lib/CheckerGranule.py
@@ -607,7 +607,7 @@ class checkerRules():
                 return "Recommend providing a description for each Online Access URL."
         else:
             for i in range(0, length):
-                if val[i]['URLDescription'] == None:
+                if val[i].get('URLDescription') == None:
                     return "Recommend providing a description for each Online Access URL."
         return "OK - quality check"
 


### PR DESCRIPTION
This fixes the issue relating to AIRXAMAP not ingesting.   This was due to a key error trying to access val[i]['URLDescription'].   The way to do it without generating KeyError is by using .get() instead, i.e.:
if val[i].get('URLDescription') == None: