### PR TITLE
Hotfix/cmrarc 419

### DIFF
--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -408,35 +408,35 @@ class Cmr
 
     if free_text
       free_text = free_text.strip
-      base_options = {"page_size" => page_size, "page_num" => curr_page}
+      base_options = {'page_size' => page_size, 'page_num' => curr_page}
       #setting the provider params
       if provider == ANY_DAAC_KEYWORD
-        base_options["provider"] = PROVIDERS
-        base_options["provider"] << "ARCTEST"
+        base_options['provider'] = PROVIDERS
+        base_options['provider'] << 'ARCTEST'
       else
-        base_options["provider"] = provider
+        base_options['provider'] = provider
       end
 
       #setting the two versions of free text search we want to run (with/without first char wildcard)
       options = base_options.clone
-      options["keyword"] = "*#{free_text}*"
+      options['keyword'] = "*#{free_text}*"
       options_first_char = base_options.clone
-      options_first_char["keyword"] = "#{free_text}*"
+      options_first_char['keyword'] = "#{free_text}*"
 
-      query_text = Cmr.api_url("collections", "echo10", options)
+      query_text = Cmr.api_url('collections', 'echo10', options)
 
       #cmr does not accept first character wildcards for some reason, so remove char and retry query
-      query_text_first_char = Cmr.api_url("collections", "echo10", options_first_char)
+      query_text_first_char = Cmr.api_url('collections', 'echo10', options_first_char)
 
       begin
         raw_xml = Cmr.cmr_request(query_text).parsed_response
-        search_results = Hash.from_xml(raw_xml)["results"]
+        search_results = Hash.from_xml(raw_xml)['results']
 
         #rerun query with first wildcard removed
-        if search_results["hits"].to_i == 0
+        if search_results['hits'].to_i == 0
           raw_xml = Cmr.cmr_request(query_text_first_char).parsed_response
-          search_results = Hash.from_xml(raw_xml)["results"]
-          if search_results["hits"].to_i > 0
+          search_results = Hash.from_xml(raw_xml)['results']
+          if search_results['hits'].to_i > 0
             Rails.logger.info("cmr search for #{free_text} with wildcard on suffix ONLY worked.")
           end
         end
@@ -445,12 +445,12 @@ class Cmr
       end
 
 
-      collection_count = search_results["hits"].to_i
+      collection_count = search_results['hits'].to_i
 
-      if search_results["hits"].to_i > 1
-        search_iterator = search_results["result"]
-      elsif search_results["hits"].to_i == 1
-        search_iterator = [search_results["result"]]
+      if search_results['hits'].to_i > 1
+        search_iterator = search_results['result']
+      elsif search_results['hits'].to_i == 1
+        search_iterator = [search_results['result']]
       else
         search_iterator = []
       end

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -412,6 +412,7 @@ class Cmr
       #setting the provider params
       if provider == ANY_DAAC_KEYWORD
         base_options["provider"] = PROVIDERS
+        base_options["provider"] << "ARCTEST"
       else
         base_options["provider"] = provider
       end

--- a/lib/CheckerGranule.py
+++ b/lib/CheckerGranule.py
@@ -607,7 +607,7 @@ class checkerRules():
                 return "Recommend providing a description for each Online Access URL."
         else:
             for i in range(0, length):
-                if val[i]['URLDescription'] == None:
+                if val[i].get('URLDescription') == None:
                     return "Recommend providing a description for each Online Access URL."
         return "OK - quality check"
 


### PR DESCRIPTION
Since we setup a new provider called ARCTEST, this code includes this in the list of providers to search, so these records can be found.  Note I didn't change the PROVIDER list as I don't want ARCTEST showing up in the list of providers available in the search page or in the metrics.