### PR TITLE
CMRARC-426 removed older eui css reference

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
 
-  <link href="https://cdn.earthdata.nasa.gov/eui/1.1.3/stylesheets/application.css" rel="stylesheet"/>
   <%# See https://guides.rubyonrails.org/security.html#csrf-countermeasures %>
   <%# See https://medium.com/rubyinside/a-deep-dive-into-csrf-protection-in-rails-19fa0a42c0ef %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Charles noticed a reference to an older version of eui, removing as these are imported automatically now.