### PR TITLE
CMRARC-379 more fixes to broken tests

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -166,7 +166,6 @@ class Collection < ActiveRecord::Base
     record = self.records[0]
     native_format = record.format
 
-
     #only selecting granules for certain formats per business rules
     if Collection::INCLUDE_GRANULE_FORMATS.include? native_format
       #creating all the Granule related objects
@@ -195,7 +194,7 @@ class Collection < ActiveRecord::Base
       end
 
     }
-    granules_components[0] # returns the granule object
+    return granules_components.flatten[0] # returns the granule object
   end
 
 

--- a/test/controllers/granules_controller_test.rb
+++ b/test/controllers/granules_controller_test.rb
@@ -88,8 +88,7 @@ class GranulesControllerTest < ActionController::TestCase
       # before we do post, there should be 2 granule revisions, 1 and 6
       granule = Granule.first
       records = granule.records
-      records.sort { |a,b| a.revision_id.to_i <=> b.revision_id.to_i }
-      records = granule.records.order(:revision_id)
+      records = records.sort { |a,b| a.revision_id.to_i <=> b.revision_id.to_i }
       no_granules_before = records.count
       assert_equal records.last.revision_id,"6"
       post :pull_latest, id: granule.id
@@ -98,7 +97,8 @@ class GranulesControllerTest < ActionController::TestCase
       # revision stubbed above, #15
       granule = Granule.first
       records = granule.records
-      records.sort { |a,b| a.revision_id.to_i <=> b.revision_id.to_i }
+      records = records.sort { |a,b| a.revision_id.to_i <=> b.revision_id.to_i }
+
       no_granules_after = granule.records.count
       assert_equal no_granules_after, (no_granules_before + 1)
       assert_equal "A new granule revision has been added for this collection.", flash[:notice]

--- a/test/fixtures/records.yml
+++ b/test/fixtures/records.yml
@@ -13,18 +13,21 @@ granule:
   recordable_type: "Granule"
   revision_id: "1"
   state: "in_arc_review"
+  format: "echo10"
 
 metric1:
   id: 10
   recordable_id: 2
   recordable_type: "Collection"
   revision_id: "8"
+  format: "dif10"
 
 metric2:
   id: 11
   recordable_id: 3
   recordable_type: "Collection"
   revision_id: "8"
+  format: "dif10"
 
 in_daac_review:
   id: 12
@@ -32,6 +35,7 @@ in_daac_review:
   recordable_type: "Collection"
   revision_id: "8"
   state: "in_daac_review"
+  format: "dif10"
 
 in_arc_review:
   id: 13
@@ -39,6 +43,7 @@ in_arc_review:
   recordable_type: "Collection"
   revision_id: "6"
   state: "in_arc_review"
+  format: "dif10"
 
 podaac_in_daac_review:
   id: 14
@@ -46,6 +51,7 @@ podaac_in_daac_review:
   recordable_type: "Collection"
   revision_id: "7"
   state: "in_daac_review"
+  format: "dif10"
 
 closed:
   id: 15
@@ -53,6 +59,7 @@ closed:
   recordable_type: "Collection"
   revision_id: 4
   state: "closed"
+  format: "dif10"
 
 open_granule:
   id: 16
@@ -60,4 +67,6 @@ open_granule:
   recordable_type: "Granule"
   revision_id: "6"
   state: "open"
+  format: "echo10"
+
 


### PR DESCRIPTION
the db:reset pull data in a different order, thus needed to have the format field included in the fixture.