### PR TITLE
Feature/cmrarc 369- fixed version field in home table

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,10 +53,7 @@ class ApplicationController < ActionController::Base
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
 
     # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    # record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?) or record_data.feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct;
-    record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?), 'VersionId', 'Entry_ID/Version', 'Version'").distinct
-    @records = record_set1
-                 #.or(record_set2)
+    @records = @records.joins(:record_datas).where("record_data.column_name IN (?, ?, ?) OR feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,9 +53,9 @@ class ApplicationController < ActionController::Base
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
 
     # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    record_set1 = @records.left_outer_joins(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).distinct
-    record_set2 = @records.left_outer_joins(:record_datas).where(record_data: { feedback: true }).distinct
-    @records = record_set1.or(record_set2)
+    record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?) or record_data.feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct;
+    @records = record_set1
+                 #.or(record_set2)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
     @records = @records.includes({ingest: :user}, :reviews)
 
     # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    @records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).or(@records.includes(:record_datas).where(record_data: {feedback:true})).references(:record_data)
+    @records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data).or(@records.includes(:record_datas).where(record_data: { feedback: true })).references(:record_data)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,8 @@ class ApplicationController < ActionController::Base
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
 
     # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?) or record_data.feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct;
+    # record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?) or record_data.feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct;
+    record_set1 = @records.left_outer_joins(:record_datas).where("record_data.column_name IN (?, ?, ?), 'VersionId', 'Entry_ID/Version', 'Version'").distinct
     @records = record_set1
                  #.or(record_set2)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,13 +49,17 @@ class ApplicationController < ActionController::Base
       @records = @records.campaign(params[:campaign])
     end
 
-    # Count Second Opinions here for every record
+    # # Count Second Opinions here for every record
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
-
     @records = @records.includes({ingest: :user}, :reviews)
 
-    # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    @records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data).or(@records.includes(:record_datas).where(record_data: { feedback: true })).references(:record_data)
+    record_set1 = @records.left_outer_joins(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data)
+    record_set2 = @records.left_outer_joins(:record_datas).where(record_data: { feedback: true }).references(:record_data)
+    @records = record_set1.or(record_set2)
+
+    #
+    # # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
+    # @records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data).or(@records.includes(:record_datas).where(record_data: { feedback: true })).references(:record_data)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,11 +49,11 @@ class ApplicationController < ActionController::Base
       @records = @records.campaign(params[:campaign])
     end
 
-    # # Count Second Opinions here for every record
+    # Count Second Opinions here for every record
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
 
-    # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    @records = @records.joins(:record_datas).where("record_data.column_name IN (?, ?, ?) OR feedback = ?", 'VersionId', 'Entry_ID/Version', 'Version', true).distinct
+    # only include collection records
+    @records = @records.where(recordable_type: 'Collection').distinct
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,15 +51,11 @@ class ApplicationController < ActionController::Base
 
     # # Count Second Opinions here for every record
     @second_opinion_counts = RecordData.where(record: @records, opinion: true).group(:record_id).count
-    @records = @records.includes({ingest: :user}, :reviews)
 
-    record_set1 = @records.left_outer_joins(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data)
-    record_set2 = @records.left_outer_joins(:record_datas).where(record_data: { feedback: true }).references(:record_data)
-    @records = record_set1.or(record_set2).distinct
-
-    #
-    # # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
-    # @records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data).or(@records.includes(:record_datas).where(record_data: { feedback: true })).references(:record_data)
+    # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that
+    record_set1 = @records.left_outer_joins(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).distinct
+    record_set2 = @records.left_outer_joins(:record_datas).where(record_data: { feedback: true }).distinct
+    @records = record_set1.or(record_set2)
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
 
     record_set1 = @records.left_outer_joins(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data)
     record_set2 = @records.left_outer_joins(:record_datas).where(record_data: { feedback: true }).references(:record_data)
-    @records = record_set1.or(record_set2)
+    @records = record_set1.or(record_set2).distinct
 
     #
     # # Version ID, Version, or Feedback records are the only field we need to render on the home page, so just load that

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -172,6 +172,9 @@ class Record < ApplicationRecord
     end
   end
 
+  def version
+    self.record_datas.where(column_name: ['VersionId', 'Entry_ID/Version', 'Version']).first.value
+  end
 
   # ====Params
   # None

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -173,7 +173,8 @@ class Record < ApplicationRecord
   end
 
   def version
-    self.record_datas.where(column_name: ['VersionId', 'Entry_ID/Version', 'Version']).first.value
+    data = record_datas.where(column_name: ['VersionId', 'Entry_ID/Version', 'Version']).first
+    data.nil? ? 'n/a' : data.value
   end
 
   # ====Params

--- a/app/views/shared/_records_table.html.erb
+++ b/app/views/shared/_records_table.html.erb
@@ -57,10 +57,7 @@
           <% end %>
         </table>
       </div>
-      <p>Total Records: <%= records.count %></p>
-
       <br>
-
       <%= content_for :form_buttons %>
     </div>
   <% end %>

--- a/app/views/shared/_records_table.html.erb
+++ b/app/views/shared/_records_table.html.erb
@@ -41,7 +41,7 @@
               <td class="center_text"><%= record.revision_id %></td>
               <td><%= record.recordable.short_name %></td>
               <!-- Only Version ID should be loaded -->
-              <td class="center_text"><%= record.record_datas.first.value%></td>
+              <td class="center_text"><%= record.version%></td>
               <td><%= record.ingested_by %></td>
               <% if closed %>
                 <td><%= record.formatted_closed_date %></td>

--- a/app/views/shared/_records_table.html.erb
+++ b/app/views/shared/_records_table.html.erb
@@ -57,6 +57,7 @@
           <% end %>
         </table>
       </div>
+      <p>Total Records: <%= records.count %></p>
 
       <br>
 

--- a/test/features/can_revert_record_test.rb
+++ b/test/features/can_revert_record_test.rb
@@ -22,7 +22,8 @@ class CanRevertRecordTest < Capybara::Rails::TestCase
       visit '/home'
 
       within '#in_daac_review' do
-        check 'record_id_'
+        page.save_and_open_page
+        all('#record_id_')[0].click
         within '.navigate-buttons' do
           click_on 'See Review Detail'
         end
@@ -30,7 +31,7 @@ class CanRevertRecordTest < Capybara::Rails::TestCase
       click_on 'Curation Home'
 
       within '#in_daac_review' do
-        check 'record_id_'
+        all('#record_id_')[0].click
         within '.navigate-buttons' do
           click_on 'Revert'
         end

--- a/test/features/can_revert_record_test.rb
+++ b/test/features/can_revert_record_test.rb
@@ -22,7 +22,6 @@ class CanRevertRecordTest < Capybara::Rails::TestCase
       visit '/home'
 
       within '#in_daac_review' do
-        page.save_and_open_page
         all('#record_id_')[0].click
         within '.navigate-buttons' do
           click_on 'See Review Detail'

--- a/test/features/curator_feedback_test.rb
+++ b/test/features/curator_feedback_test.rb
@@ -106,6 +106,7 @@ class CuratorFeedbackTest < Capybara::Rails::TestCase
         assert has_content?('C1000000020-LANCEAMSR2')
       end
       within '#in_daac_review' do
+        page.save_and_open_screenshot
         check 'record_id_'
         within '.navigate-buttons' do
           accept_alert do

--- a/test/features/curator_feedback_test.rb
+++ b/test/features/curator_feedback_test.rb
@@ -106,7 +106,6 @@ class CuratorFeedbackTest < Capybara::Rails::TestCase
         assert has_content?('C1000000020-LANCEAMSR2')
       end
       within '#in_daac_review' do
-        page.save_and_open_screenshot
         check 'record_id_'
         within '.navigate-buttons' do
           accept_alert do

--- a/test/features/curator_feedback_test.rb
+++ b/test/features/curator_feedback_test.rb
@@ -30,7 +30,7 @@ class CuratorFeedbackTest < Capybara::Rails::TestCase
 
       visit '/home'
       within '#in_daac_review' do
-        check 'record_id_'
+        all('#record_id_')[0].click
         within '.navigate-buttons' do
           click_on 'See Review Detail'
         end
@@ -106,7 +106,7 @@ class CuratorFeedbackTest < Capybara::Rails::TestCase
         assert has_content?('C1000000020-LANCEAMSR2')
       end
       within '#in_daac_review' do
-        check 'record_id_'
+        all('#record_id_')[0].click
         within '.navigate-buttons' do
           accept_alert do
             click_on 'Close'


### PR DESCRIPTION
So it ended up being that the join worked as expected and all the results returned was as expected.   The issue was that the original query to pull in all collection records did this:
`@records = @records.includes(:record_datas).where(record_data: { column_name: ['VersionId', 'Entry_ID/Version', 'Version']}).references(:record_data)`

So this query retrieves all records and includes only record datas where the column name is : `VersionId, Entry_ID/Version, or Version. `

Then in the ERB file it pulled out the version in the table like so:
`<td class="center_text"><%= record.record_datas.first.value%></td>
`
So this rendering makes the assumption that the only record datas included as part of the record is version record data.   When I added feedback data to the query, now we've got record data with feedback data as well as version data.  That is where the error occurred.
To fix this, I simply made a version property in the model and now retrieving the version like so:

> def version
>     data = record_datas.where(column_name: ['VersionId', 'Entry_ID/Version', 'Version']).first
>     data.nil? ? 'n/a' : data.value
>   end

Then I can use that property rather than the assumptions stated above and was free to change the initial query to return all collection records rather than only those with those version fields.  That query now looks like so:
`    # only include collection records
    @records = @records.where(recordable_type: 'Collection').distinct`


