### PR TITLE
CMRARC-543 fixed valueerror with bad urls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (4.0.1)
     puma (3.12.2)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -57,7 +57,7 @@ class Collection < Metadata
 
       # In production there is an egress issue with certain link types given in metadata
       # AWS hangs requests that break ingress/egress rules.  Added this timeout to catch those
-      Timeout::timeout(40) {new_record.create_script} if options[:run_script]
+      Timeout::timeout(90) {new_record.create_script} if options[:run_script]
 
       collection.add_granule(user) if options[:add_granule]
 

--- a/lib/CheckerCollection.py
+++ b/lib/CheckerCollection.py
@@ -896,7 +896,7 @@ class checkerRules():
 
                 if connection:
                     connection.close()
-            except (urllib2.HTTPError, urllib2.URLError, socket.timeout) as e:
+            except (urllib2.HTTPError, urllib2.URLError, socket.timeout, ValueError) as e:
                 return "Broken link: " + val
         else:
             for i in range(0, length):
@@ -905,11 +905,11 @@ class checkerRules():
                         return "np"
                     if val[i]['URL'].startswith('ftp://'):
                         return "Please replace the current ftp link with a link to directly download the data via https. The link should run through URS and point as directly to the data as possible (i.e. the user should not have to click through sub directories to access data pertinent to this collection)."
-                    connection = urllib2.urlopen(val[i]['URL'], timeout=5)
+                    connection = urllib2.urlopen(val[i]['URL'], timeout=LINK_CHECK_TIMEOUT)
                     if connection:
                         connection.close()
 
-                except (urllib2.HTTPError, urllib2.URLError, socket.timeout) as e:
+                except (urllib2.HTTPError, urllib2.URLError, socket.timeout, ValueError) as e:
                     msg += "Broken link: " + val[i]['URL'] + ";"
                     brokenURLcount += 1
                     # return "Broken link: " + val[i]['URL']


### PR DESCRIPTION
Fixed a minor bug in dashboard where broken urls were throwing an valueerror and this was not caught.  I also increased the timeout since some documents have a lot of urls