### PR TITLE
Hotfix/CMRARC-545-2 Updating for requested changes and message-id

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'no-reply@cmr-dashboard.earthdata.nasa.gov'
+  default from: "no-reply@#{Rails.configuration.default_email_domain}"
+  # Lambda to construct unique message ids for each mail.
+  default 'Message-ID' => -> { "<#{SecureRandom.uuid}@#{Rails.configuration.default_email_domain}>" }
   layout 'mailer'
 end

--- a/app/views/daac_curator_mailer/released_records_digest_notification.html.erb
+++ b/app/views/daac_curator_mailer/released_records_digest_notification.html.erb
@@ -13,7 +13,7 @@
     <tbody>
       <% @records.first(50).each do |record| %>
         <tr>
-          <td><%= link_to(record.collection? ? record.short_name : record.long_name, reports_review_url(record_id: record.id)) %></td>
+          <td><%= link_to(record.short_name, reports_review_url(record_id: record.id)) %></td>
           <td><%= record.released_to_daac_date %></td>
         </tr>
       <% end %>

--- a/app/views/daac_curator_mailer/released_records_digest_notification.text.erb
+++ b/app/views/daac_curator_mailer/released_records_digest_notification.text.erb
@@ -4,7 +4,7 @@ The following Curation Dashboard reports are available for your review:
 
 <%= sprintf("%-32.30s%-26.26s%s\r\n", 'Record Name', 'Date Released', 'Available At') %>
 <% @records.each do |record| %>
-<%= sprintf("%-32.30s%-26.26s%s\r\n", record.collection? ? record.short_name : record.long_name, record.released_to_daac_date, reports_review_url(record_id: record.id)) %>
+<%= sprintf("%-32.30s%-26.26s%s\r\n", record.short_name, record.released_to_daac_date, reports_review_url(record_id: record.id)) %>
 <% end %>
 
 You can view all available (<%= @records.count %>) reports in the Curation Dashboard by going to: <%= home_url %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,4 +74,5 @@ Rails.application.configure do
   config.email_preference_feature_toggle = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
+  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,5 +74,5 @@ Rails.application.configure do
   config.email_preference_feature_toggle = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
-  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
+  config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,6 +125,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-
   config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,5 +125,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
+  config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,4 +125,6 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+
+  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -125,5 +125,7 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+  # This domain has been configured to pass DMARC authentication.  Changing to a
+  # domain which has not been will cause gmail to reject our e-mails
   config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -89,5 +89,7 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+  # This domain has been configured to pass DMARC authentication.  Changing to a
+  # domain which has not been will cause gmail to reject our e-mails
   config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -89,5 +89,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
+  config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -89,6 +89,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-
   config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/sit.rb
+++ b/config/environments/sit.rb
@@ -89,4 +89,6 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+
+  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,4 +53,5 @@ Rails.application.configure do
   config.email_preference_feature_toggle = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
+  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,5 +53,5 @@ Rails.application.configure do
   config.email_preference_feature_toggle = true
 
   config.action_mailer.default_url_options = { host: 'localhost', port: '3000' }
-  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
+  config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -89,5 +89,7 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+  # This domain has been configured to pass DMARC authentication.  Changing to a
+  # domain which has not been will cause gmail to reject our e-mails
   config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -89,5 +89,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
+  config.default_email_domain = 'earthdata.nasa.gov'
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -89,6 +89,5 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
-
   config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/environments/uat.rb
+++ b/config/environments/uat.rb
@@ -89,4 +89,6 @@ Rails.application.configure do
   config.tag_manager_id = 'GTM-WNP7MLF'
 
   config.email_preference_feature_toggle = true
+
+  config.default_email_domain = 'cmr-dashboard.earthdata.nasa.gov'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,7 @@
 # Use this file to easily define all of your cron jobs.
 
+# Need to set the path so that the machine can find bundle to run the rake task
 ruby_path = File.expand_path('..', %x(which ruby))
-
 env :PATH, "#{ruby_path}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 set :output, 'log/session_cleanup_cron.log'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,6 +10,6 @@ every 1.day, at: '4:00 am' do
 end
 
 set :output, 'log/digest_emails.log'
-every 1.day, at: '2:00 am' do
+every 30.minutes do
   rake 'daac_curator_emails_cron:send_emails'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,7 +1,7 @@
 # Use this file to easily define all of your cron jobs.
 
-# Need to set the path so that the machine can find bundle to run the rake task
 ruby_path = File.expand_path('..', %x(which ruby))
+
 env :PATH, "#{ruby_path}:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
 set :output, 'log/session_cleanup_cron.log'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -10,6 +10,6 @@ every 1.day, at: '4:00 am' do
 end
 
 set :output, 'log/digest_emails.log'
-every 30.minutes do
+every 1.day, at: '2:00 am' do
   rake 'daac_curator_emails_cron:send_emails'
 end

--- a/lib/rake_helpers/daac_curator_mailer_helper.rb
+++ b/lib/rake_helpers/daac_curator_mailer_helper.rb
@@ -18,7 +18,7 @@ class DaacCuratorMailerOrchestration
     # For each daac where anyone receives an e-mail...
     daacs.each do |daac|
       # Find relevant records or abort
-      records = Record.where(state: :in_daac_review, daac: daac).order(released_to_daac_date: :desc)
+      records = Record.where(state: :in_daac_review, recordable_type: 'Collection', daac: daac).order(released_to_daac_date: :desc)
       next if records.blank?
 
       # Find each curator who should receive an e-mail today

--- a/test/fixtures/collections.yml
+++ b/test/fixtures/collections.yml
@@ -18,3 +18,8 @@ daac_curator_mailer_collection:
   concept_id: "daac_curator_mailer_collection-OB_DAAC"
   short_name: "daac_curator_mailer_collection"
   
+daac_curator_mailer_collection2:
+  id: 5
+  concept_id: "daac_curator_mailer_collection2-OB_DAAC"
+  short_name: "daac_curator_mailer_collection2"
+  

--- a/test/fixtures/daac_curator_mailer/released_records_digest_notification_html_part
+++ b/test/fixtures/daac_curator_mailer/released_records_digest_notification_html_part
@@ -173,7 +173,7 @@
           <td>2002-10-31 05:00:00 UTC</td>
         </tr>
         <tr>
-          <td><a href="http://localhost:3000/reports/review?record_id=23">Test GranuleUR</a></td>
+          <td><a href="http://localhost:3000/reports/review?record_id=25">Test Short Name3</a></td>
           <td>2002-10-31 05:00:00 UTC</td>
         </tr>
     </tbody>

--- a/test/fixtures/daac_curator_mailer/released_records_digest_notification_text_part
+++ b/test/fixtures/daac_curator_mailer/released_records_digest_notification_text_part
@@ -6,7 +6,7 @@ Record Name                     Date Released             Available At
 
 Test Short Name                 2002-10-31 05:00:00 UTC   http://localhost:3000/reports/review?record_id=22
 
-Test GranuleUR                  2002-10-31 05:00:00 UTC   http://localhost:3000/reports/review?record_id=23
+Test Short Name3                2002-10-31 05:00:00 UTC   http://localhost:3000/reports/review?record_id=25
 
 
 You can view all available (2) reports in the Curation Dashboard by going to: http://localhost:3000/home

--- a/test/fixtures/record_data.yml
+++ b/test/fixtures/record_data.yml
@@ -259,4 +259,10 @@ digest_email_collection2_short_name:
   id: 33
   record_id: 24
   column_name: ShortName
-  value: Test Short Name
+  value: Test Short Name2
+  
+digest_email_collection3_short_name:
+  id: 34
+  record_id: 25
+  column_name: ShortName
+  value: Test Short Name3

--- a/test/fixtures/records.yml
+++ b/test/fixtures/records.yml
@@ -142,3 +142,12 @@ digest_email_collection2:
   revision_id: 1
   released_to_daac_date: 2002-10-31 00:00:00 -0500
   daac: NSIDC
+  
+digest_email_collection3:
+  id: 25
+  recordable_id: 5
+  recordable_type: Collection
+  state: in_daac_review
+  revision_id: 1
+  released_to_daac_date: 2002-10-31 00:00:00 -0500
+  daac: OB_DAAC

--- a/test/mailers/daac_curator_mailer_test.rb
+++ b/test/mailers/daac_curator_mailer_test.rb
@@ -12,7 +12,7 @@ class DaacCuratorMailerTest < ActionMailer::TestCase
       end
 
       assert_equal ['fake_daac_curator1@fake.com', 'fake_daac_curator2@fake.com'], email.to
-      assert_equal ['no-reply@cmr-dashboard.earthdata.nasa.gov'], email.from
+      assert_equal ['no-reply@earthdata.nasa.gov'], email.from
       assert_equal 'Summary of Reports Available to OB_DAAC', email.subject
       assert_equal read_fixture('released_records_digest_notification_text_part').join, email.text_part.body.to_s
       assert_equal read_fixture('released_records_digest_notification_html_part').join, email.html_part.body.to_s

--- a/test/mailers/daac_curator_mailer_test.rb
+++ b/test/mailers/daac_curator_mailer_test.rb
@@ -5,7 +5,7 @@ class DaacCuratorMailerTest < ActionMailer::TestCase
 
   describe 'released_records_digest_notification email appearance' do
     it 'correctly populates the fields of an email' do
-      email = DaacCuratorMailer.released_records_digest_notification([User.find(7), User.find(8)], [Record.find(22), Record.find(23)], 'OB_DAAC')
+      email = DaacCuratorMailer.released_records_digest_notification([User.find(7), User.find(8)], [Record.find(22), Record.find(25)], 'OB_DAAC')
 
       assert_emails 1 do
         email.deliver_now


### PR DESCRIPTION
The Message-ID does not appear to be sufficient to get gmail delivery, but is necessary, so I left the changes in.  The rest of the changes are to accommodate a request to not show granules.