### PR TITLE
CMRARC-591 - removed unnecessary test

### DIFF
--- a/test/features/curator_feedback_test.rb
+++ b/test/features/curator_feedback_test.rb
@@ -99,25 +99,6 @@ class CuratorFeedbackTest < Capybara::Rails::TestCase
       end
     end
 
-    it 'curator feedback disappears when record is closed' do
-      mock_login(role: "admin") # admin
-      visit '/home'
-      within '#provide_feedback' do
-        assert has_content?('C1000000020-LANCEAMSR2')
-      end
-      within '#in_daac_review' do
-        all('#record_id_')[0].click
-        within '.navigate-buttons' do
-          accept_alert do
-            click_on 'Close'
-          end
-        end
-      end
-      within '#provide_feedback' do
-        refute has_content?('C1000000020-LANCEAMSR2')
-      end
-
-    end
   end
 
 


### PR DESCRIPTION
removed unnecessary test, as it is now impossible to close a record when it is in feedback.   They must first move the record out of feedback to close it.