### PR TITLE
CMRARC-731: Keywords and Abstract successfully pulled from collection

### DIFF
--- a/app/controllers/gkr_keyword_comparison_controller.rb
+++ b/app/controllers/gkr_keyword_comparison_controller.rb
@@ -8,9 +8,9 @@ class GkrKeywordComparisonController < ApplicationController
     concept_id = params[:concept_id]
     threshold = params[:threshold]
     collection = Cmr.get_raw_collection(concept_id, 'umm_json')
-    abstract_p = collection['Abstract']
-    cmr_keywords_p = collection['ScienceKeywords']
+    abstract_for_gkr = collection['Abstract']
+    curated_science_keywords = collection['ScienceKeywords']
 
-    redirect_to gkr_keyword_comparison_path(abstract: abstract_p, cmr_keywords: cmr_keywords_p)
+    redirect_to gkr_keyword_comparison_path(abstract: abstract_for_gkr, cmr_keywords: curated_science_keywords)
   end
 end

--- a/app/controllers/gkr_keyword_comparison_controller.rb
+++ b/app/controllers/gkr_keyword_comparison_controller.rb
@@ -1,6 +1,7 @@
 class GkrKeywordComparisonController < ApplicationController
   def show
     @abstract = params[:abstract]
+    @cmr_keywords = params[:cmr_keywords]
   end
 
   def create
@@ -8,7 +9,8 @@ class GkrKeywordComparisonController < ApplicationController
     threshold = params[:threshold]
     collection = Cmr.get_raw_collection(concept_id, 'umm_json')
     abstract_p = collection['Abstract']
- 
-    redirect_to gkr_keyword_comparison_path(abstract: abstract_p)
+    cmr_keywords_p = collection['ScienceKeywords']
+
+    redirect_to gkr_keyword_comparison_path(abstract: abstract_p, cmr_keywords: cmr_keywords_p)
   end
 end

--- a/app/views/gkr_keyword_comparison/show.html.erb
+++ b/app/views/gkr_keyword_comparison/show.html.erb
@@ -13,8 +13,11 @@
 <% end %>
 <br>
 <br>
-<h1 style='color: white'> Abstract: </h1>
-<p style='color: white'> <%= @abstract %> </p>
+
+<% if @abstract != nil then %>
+  <h1 style='color: white'> Abstract: </h1>
+  <p style='color: white'> <%= @abstract %> </p>
+<% end %>
 
 <% if @cmr_keywords != nil then %>
   <h1 style='color: white'> Keywords: </h1>

--- a/app/views/gkr_keyword_comparison/show.html.erb
+++ b/app/views/gkr_keyword_comparison/show.html.erb
@@ -14,12 +14,12 @@
 <br>
 <br>
 
-<% if @abstract != nil then %>
+<% if @abstract %>
   <h1 style='color: white'> Abstract: </h1>
   <p style='color: white'> <%= @abstract %> </p>
 <% end %>
 
-<% if @cmr_keywords != nil then %>
+<% if @cmr_keywords %>
   <h1 style='color: white'> Keywords: </h1>
   <% @cmr_keywords.each do |keyword| %>
     <p style='color: white'> <%= keyword %> </p>

--- a/app/views/gkr_keyword_comparison/show.html.erb
+++ b/app/views/gkr_keyword_comparison/show.html.erb
@@ -15,3 +15,13 @@
 <br>
 <h1 style='color: white'> Abstract: </h1>
 <p style='color: white'> <%= @abstract %> </p>
+
+<% if @cmr_keywords != nil then %>
+  <h1 style='color: white'> Keywords: </h1>
+  <% @cmr_keywords.each do |keyword| %>
+    <p style='color: white'> <%= keyword %> </p>
+  <% end %>
+<% end %>
+
+
+

--- a/test/features/gkr_keyword_comparison_test.rb
+++ b/test/features/gkr_keyword_comparison_test.rb
@@ -29,6 +29,7 @@ class GkrKeywordComparisonTest < SystemTestCase
       click_on 'Submit'
 
       assert has_content?('The National Center for Environmental Prediction/Aviation Weather Center Infrared Global Geostationary Composite data set contains global composite images from the infrared channels of multiple weather satellites in geosynchronous orbit. These satellites include the GMS (Japan), GOES (USA), and Meteosat (Europe). These imagers span nearly the entire globe with a small gap over India. The data resolution is 14 km spatial with the data remapped into a Mercator projection. The data have not necessarily been cross calibrated between sensors.')
+      assert has_content?('{"Category"=>"EARTH SCIENCE", "Topic"=>"SPECTRAL/ENGINEERING", "Term"=>"INFRARED WAVELENGTHS", "VariableLevel1"=>"INFRARED IMAGERY"}')
     end
   end
 end


### PR DESCRIPTION
I was able to easily extract the abstract and science keyword values from the collection, which will be needed later on to (1) retrieve recommendations from GKR and (2) compare the keywords from CMR to GKR's recommendations. I then display those on the application. Since I am redirecting to the same view that was rendered originally, I encapsulated the code for displaying the abstract and keywords in if statements to prevent any issues with nil variables.