### PR TITLE
feature/CMRARC-772 - ECHO10 granules not ingesting correctly

### DIFF
--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -428,7 +428,7 @@ class Cmr
 
   def self.add_required_fields(collection_hash, required_fields)
     required_fields.each do |field|
-      collection_hash[field] = "" unless collection_hash[field]
+      collection_hash[field] = "" unless field.blank? || collection_hash[field]
     end
 
     collection_hash

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -495,6 +495,7 @@ class Cmr
       current_granule['format_type'] = format_type
       if format_type == 'echo10'
         current_granule = get_raw_echo10_granule_info(granule_data['meta']['concept-id'])
+        current_granule['format_type'] = 'echo10'
       else
         current_granule['concept_id'] = granule_data['meta']['concept-id']
         current_granule['revision_id'] = granule_data['meta']['revision-id']

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -237,19 +237,31 @@ class Cmr
 
   def self.format_collection(raw_collection, data_format)
     desired_fields = if data_format == "echo10"
-       DesiredFields.instance.get_format_fields('echo10')
-    elsif data_format == "dif10"
-      DesiredFields.instance.get_format_fields('dif10')
-    elsif data_format == "umm_json"
-      DesiredFields.instance.get_format_fields('ummc')
-   else
-      []
-    end
+                       DesiredFields.instance.get_format_fields('echo10')
+                     elsif data_format == "dif10"
+                       DesiredFields.instance.get_format_fields('dif10')
+                     elsif data_format == "umm_json"
+                       DesiredFields.instance.get_format_fields('ummc')
+                     else
+                       []
+                     end
+
+    required_fields = if data_format == "echo10"
+                       RequiredFields.instance.get_format_fields('echo10')
+                     elsif data_format == "dif10"
+                       RequiredFields.instance.get_format_fields('dif10')
+                     elsif data_format == "umm_json"
+                       RequiredFields.instance.get_format_fields('ummc')
+                     else
+                       []
+                     end
 
     results_hash   = flatten_collection(raw_collection)
     # Dif10 records come in with some uneeded header values
     results_hash = Cmr.remove_header_values(results_hash)
     add_required_fields(results_hash, desired_fields)
+    add_required_fields(results_hash, required_fields)
+
   end
 
   def self.get_granule_with_collection_id(concept_id)
@@ -262,8 +274,10 @@ class Cmr
     results_hash = flatten_collection(granule_raw_data)
     if format == 'echo10'
       add_required_fields(results_hash, DesiredFields.instance.get_format_fields('echo10_granule'))
+      add_required_fields(results_hash, RequiredFields.instance.get_format_fields('echo10_granule'))
     else
       add_required_fields(results_hash, DesiredFields.instance.get_format_fields('ummg'))
+      add_required_fields(results_hash, RequiredFields.instance.get_format_fields('ummg'))
     end
   end
 

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -275,10 +275,12 @@ class Cmr
     if format == 'echo10'
       add_required_fields(results_hash, DesiredFields.instance.get_format_fields('echo10_granule'))
       add_required_fields(results_hash, RequiredFields.instance.get_format_fields('echo10_granule'))
-    else
+    end
+    if format == 'umm_json'
       add_required_fields(results_hash, DesiredFields.instance.get_format_fields('ummg'))
       add_required_fields(results_hash, RequiredFields.instance.get_format_fields('ummg'))
     end
+    results_hash
   end
 
   # ====Params
@@ -514,6 +516,7 @@ class Cmr
         current_granule['concept_id'] = granule_data['meta']['concept-id']
         current_granule['revision_id'] = granule_data['meta']['revision-id']
         current_granule['Granule'] = granule_data['umm']
+        current_granule['format_type'] = 'umm_json'
       end
       result_granule_list << current_granule
     end

--- a/app/models/granule.rb
+++ b/app/models/granule.rb
@@ -80,7 +80,7 @@ class Granule < Metadata
   private
 
   def self.create_granule(granule, current_user, granule_info)
-    granule_record = Record.create(recordable: granule, revision_id: granule_info["revision_id"], daac: daac_from_concept_id(granule.concept_id), format: granule_info['format_type'])
+    granule_record = Record.create(recordable: granule, revision_id: granule_info["revision_id"], daac: daac_from_concept_id(granule.concept_id), format: granule_info['format_type'], native_format: granule_info['format_type'])
     granule_record_data_list = []
     flattened_granule_data = Cmr.flatten_format_granule_data(granule_info["Granule"], granule_info['format_type'])
 

--- a/app/models/record_formats/dif10_record.rb
+++ b/app/models/record_formats/dif10_record.rb
@@ -74,6 +74,8 @@ module RecordFormats
           file << raw_data
           file.flush
           script_results = `lib/dashboard_checker.sh #{file.path} dif10`
+          pos = script_results.index('{')
+          script_results = script_results.slice(pos..)
           new_results = ""
           script_results.each_line do |line|
             unless line.start_with? "Downloading "

--- a/app/models/record_formats/dif10_record.rb
+++ b/app/models/record_formats/dif10_record.rb
@@ -73,17 +73,10 @@ module RecordFormats
         Tempfile.create do |file|
           file << raw_data
           file.flush
-          script_results = `lib/dashboard_checker.sh #{file.path} dif10`
-          pos = script_results.index('{')
-          script_results = script_results.slice(pos..)
-          new_results = ""
-          script_results.each_line do |line|
-            unless line.start_with? "Downloading "
-              new_results << line
-              new_results << "\n"
-            end
-          end
-          script_results = new_results
+          output = `lib/dashboard_checker.sh #{file.path} dif10`
+          Rails.logger.info("Results of running dashboard checker for #{short_name}: #{output}")
+          script_results = File.read(file.path+'.out')
+          File.delete(file.path+'.out')
         end
       end
 

--- a/app/models/record_formats/echo10_record.rb
+++ b/app/models/record_formats/echo10_record.rb
@@ -96,18 +96,10 @@ module RecordFormats
             raw_data = get_raw_concept(concept_id, "echo10")
             file << raw_data
             file.flush
-            script_results = `lib/dashboard_checker.sh #{file.path} echo10`
-            pos = script_results.index('{')
-            script_results = script_results.slice(pos..)
-
-            new_results = ""
-            script_results.each_line do |line|
-              unless line.start_with? "Downloading "
-                new_results << line
-                new_results << "\n"
-              end
-            end
-            script_results = new_results
+            output = `lib/dashboard_checker.sh #{file.path} echo10`
+            Rails.logger.info("Results of running dashboard checker for #{short_name}: #{output}")
+            script_results = File.read(file.path+'.out')
+            File.delete(file.path+'.out')
           else
             file << record_json
             file.flush
@@ -118,7 +110,7 @@ module RecordFormats
         Tempfile.create do |file|
           file << record_json
           file.flush
-          script_results = `python2 -W ignore lib/GranuleChecker.py #{file.path}`
+          script_results = `lib/granule_checker.sh #{file.path}`
         end
       end
 

--- a/app/models/record_formats/echo10_record.rb
+++ b/app/models/record_formats/echo10_record.rb
@@ -97,6 +97,9 @@ module RecordFormats
             file << raw_data
             file.flush
             script_results = `lib/dashboard_checker.sh #{file.path} echo10`
+            pos = script_results.index('{')
+            script_results = script_results.slice(pos..)
+
             new_results = ""
             script_results.each_line do |line|
               unless line.start_with? "Downloading "

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,6 +1,6 @@
 <footer role="contentinfo">
   <ul class="footer-links">
-    <li><span class="version badge eui-badge--md">v <%= Rails.configuration.version %></span></li>
+    <li><span class="version badge eui-badge--md">v <%= Rails.configuration.version %>|pyQuARC <%= Rails.configuration.pyquarc_version %></span></li>
     <li>NASA Official: Stephen Berrick</li>
     <li><a href="http://www.nasa.gov/FOIA/index.html">FOIA</a></li>
     <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,9 +50,18 @@ module CmrMetadataReview
       '(unknown)'
     end
 
+    def load_pyquarc_version
+      version_file = "#{config.root}/lib/pyQuARC.egg/pyQuARC/version.txt"
+      if File.exist?(version_file)
+        return IO.read(version_file)
+      end
+      '(unknown)'
+    end
+
     config.react.jsx_transform_options = {
       optional: ["es7.classProperties"]
     }
     config.version = load_version
+    config.pyquarc_version = load_pyquarc_version
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,7 @@ module CmrMetadataReview
       '(unknown)'
     end
 
+    # Returns the version found in pyQuARC/version.txt
     def load_pyquarc_version
       version_file = "#{config.root}/lib/pyQuARC.egg/pyQuARC/version.txt"
       if File.exist?(version_file)

--- a/data/dif10_required_fields.csv
+++ b/data/dif10_required_fields.csv
@@ -1,4 +1,3 @@
-dif10_required_field
 Entry_ID/Short_Name
 Entry_ID/Version
 Entry_Title

--- a/data/dif10_section_titles.csv
+++ b/data/dif10_section_titles.csv
@@ -1,4 +1,3 @@
-dif10_section_title
 Summary
 Platform
 Science_Keywords

--- a/data/echo10_granule_required_fields.csv
+++ b/data/echo10_granule_required_fields.csv
@@ -1,4 +1,3 @@
-echo10_granule_required_field
 GranuleUR
 InsertTime
 LastUpdate

--- a/data/echo10_granule_section_titles.csv
+++ b/data/echo10_granule_section_titles.csv
@@ -1,4 +1,3 @@
-echo10_granule_section_title
 Collection
 DataGranule
 Platforms

--- a/data/echo10_required_fields.csv
+++ b/data/echo10_required_fields.csv
@@ -1,4 +1,3 @@
-echo10_required_field
 ShortName
 VersionId
 InsertTime

--- a/data/ummc_required_fields.csv
+++ b/data/ummc_required_fields.csv
@@ -1,4 +1,3 @@
-ummc_required_field
 ShortName
 Version
 EntryTitle

--- a/db/migrate/20220402153701_include_format_in_echo10_granule_records.rb
+++ b/db/migrate/20220402153701_include_format_in_echo10_granule_records.rb
@@ -1,0 +1,26 @@
+class IncludeFormatInEcho10GranuleRecords < ActiveRecord::Migration[6.0]
+  def up
+    Record.where(recordable_type: 'Granule').find_each do |record|
+      if record.format.blank?
+        success = record.update(format: 'echo10')
+        if success
+          Rails.logger.info "Successfully migrated granule record format to include echo10"
+        else
+          Rails.logger.error "Could not migrate granule record format to include echo10"
+        end
+      end
+    end
+
+    Record.where(recordable_type: 'Granule').find_each do |record|
+      if record.native_format.blank?
+        success = record.update(native_format: record.format)
+        if success
+          Rails.logger.info "Successfully migrated granule record native_format to include echo10"
+        else
+          Rails.logger.error "Could not migrate granule record native_format to include echo10"
+        end
+      end
+    end
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_05_190609) do
+ActiveRecord::Schema.define(version: 2022_04_02_153701) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,8 +85,8 @@ ActiveRecord::Schema.define(version: 2021_08_05_190609) do
   end
 
   create_table "records", id: :serial, force: :cascade do |t|
-    t.integer "recordable_id", null: false
     t.string "recordable_type", null: false
+    t.integer "recordable_id", null: false
     t.string "revision_id", null: false
     t.datetime "closed_date"
     t.string "format", default: ""
@@ -94,9 +94,9 @@ ActiveRecord::Schema.define(version: 2021_08_05_190609) do
     t.string "associated_granule_value"
     t.string "copy_recommendations_note"
     t.datetime "released_to_daac_date"
+    t.string "daac"
     t.string "campaign", default: [], null: false, array: true
     t.string "native_format"
-    t.string "daac"
     t.index ["recordable_type", "recordable_id"], name: "index_records_on_recordable_type_and_recordable_id"
   end
 

--- a/lib/dashboard_checker.py
+++ b/lib/dashboard_checker.py
@@ -91,5 +91,7 @@ if __name__ == "__main__":
         errors = error["errors"]
         for field_path in errors.keys():
             parse_checks(field_path, errors, result)
-    print(json.dumps(result))
+    out = open(file+'.out', 'w')
+    out.write(json.dumps(result))
+    out.close()
 

--- a/lib/dashboard_checker.sh
+++ b/lib/dashboard_checker.sh
@@ -3,4 +3,4 @@
 #  source /opt/rh/rh-python38/enable
 #fi
 #pyenv local 3.10.3
-python -W ignore lib/dashboard_checker.py $1 $2
+python3 -W ignore lib/dashboard_checker.py $1 $2

--- a/lib/granule_checker.sh
+++ b/lib/granule_checker.sh
@@ -2,5 +2,6 @@
 #if [ -d "/opt/rh/rh-python38" ]; then
 #  source /opt/rh/rh-python38/enable
 #fi
-#pyenv local 3.10.3
-python -W ignore lib/dashboard_checker.py $1 $2
+#pyenv local 2.7.18
+python2 -W ignore lib/GranuleChecker.py $1
+


### PR DESCRIPTION
This PR includes some other fixes as well:
1) When ingesting a random granule, the type of granule was not being set, causing issues downstream
2) Will pull in required fields into the list of desired fields so the list of bubbles includes both required and desired fields.   In testing we noticed some of the required fields were missing, given that they were not in the desired fields list.
3) The pyQuARC version is not added into the footer.
4) A migration rule was added to fix old records that didn't have a type.
5) Code no longer assumes the format with a generic else.
