### PR TITLE
Feature/cmrarc 471: Automate nightly refresh of records in dashboard

### DIFF
--- a/app/mailers/refresh_records_mailer.rb
+++ b/app/mailers/refresh_records_mailer.rb
@@ -1,0 +1,10 @@
+class RefreshRecordsMailer < ApplicationMailer
+  def release_refreshed_records(recipients, added_records, failed_records, deleted_records)
+    @added_records = added_records
+    @failed_records = failed_records
+    @deleted_records = deleted_records
+    time = Time.new
+    timestamp = time.strftime("%d/%m/%Y %I:%M %p")
+    mail(to: recipients, subject: "Summary of Refresh Records on #{timestamp}")
+  end
+end

--- a/app/models/cmr.rb
+++ b/app/models/cmr.rb
@@ -85,18 +85,18 @@ class Cmr
       if cmr_revision_id > latest_revision_id
         begin
           new_record = Collection.create_new_record(record.concept_id, cmr_revision_id, current_user, false)
-          added_records << [record.concept_id, cmr_revision_id]
+          added_records << [record.concept_id, cmr_revision_id, record.state]
           Rails.logger.info "refresh-record NEW #{record.concept_id} #{record.revision_id} #{cmr_revision_id}"
         rescue Timeout::Error
           Rails.logger.error("refresh-record py-cmr timeout error #{record.concept_id} #{record.revision_id}")
-          failed_records << [record.concept_id, cmr_revision_id]
+          failed_records << [record.concept_id, cmr_revision_id, record.state]
         rescue StandardError => e
           Rails.logger.error("refresh-record error #{record.concept_id} #{record.revision_id} #{e.message}")
-          failed_records << [record.concept_id, cmr_revision_id]
+          failed_records << [record.concept_id, cmr_revision_id, record.state]
         end
       else
         Rails.logger.info "refresh-record EXISTS #{record.concept_id} #{record.revision_id} #{cmr_revision_id}"
-        deleted_records << [record.concept_id, latest_revision_id]
+        deleted_records << [record.concept_id, latest_revision_id, record.state]
       end
     end
 

--- a/app/views/refresh_records_mailer/release_refreshed_records.html.erb
+++ b/app/views/refresh_records_mailer/release_refreshed_records.html.erb
@@ -1,0 +1,48 @@
+<h1 class='styled-heading'>Refresh Records Report</h1>
+<div class= 'email-message'>
+  <p>The following Curation Dashboard records have been refreshed:</p>
+
+  <table>
+    <thead>
+    <tr>
+      <th>Status</th>
+      <th>State</th>
+      <th>Concept ID</th>
+      <th>Revision ID</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @added_records.each do |record| %>
+      <tr>
+        <td>Record Added</td>
+        <td><%= record[2].upcase %></td>
+        <td><%= record[0] %></td>
+        <td><%= record[1] %></td>
+      </tr>
+    <% end %>
+
+    <% @failed_records.each do |record| %>
+      <tr>
+        <td>Failed Ingest</td>
+        <td><%= record[2].upcase %></td>
+        <td><%= record[0] %></td>
+        <td><%= record[1] %></td>
+      </tr>
+    <% end %>
+
+    <% @deleted_records.each do |record| %>
+      <tr>
+        <td>No Longer in CMR</td>
+        <td><%= record[2].upcase %></td>
+        <td><%= record[0] %></td>
+        <td><%= record[1] %></td>
+      </tr>
+    <% end %>
+
+    </tbody>
+  </table>
+</div>
+
+<div class="email-footer">
+  <img src="https://cdn.earthdata.nasa.gov/eui/latest/docs/assets/ed-logos/meatball.png" alt="Meatball" class="image-center" />
+</div>

--- a/app/views/refresh_records_mailer/release_refreshed_records.text.erb
+++ b/app/views/refresh_records_mailer/release_refreshed_records.text.erb
@@ -1,0 +1,13 @@
+Refresh Records Report:
+
+The following Curation Dashboard records have been refreshed:
+<%= sprintf("%-32.30s%-26.26s\r\n", 'Status', 'State', 'Concept_ID', 'Revision_ID') %>
+<% @added_records.each do |record| %>
+  <%= sprintf("%-20.30s%-26.26s-26.26s-26.26s\r\n", 'Record Added', record[2].upcase,record[0],record[1]) %>
+<% end %>
+<% @failed_records.each do |record| %>
+  <%= sprintf("%-20.30s%-26.26s-26.26s-26.26s\r\n", 'Failed Ingest', record[2].upcase,record[0],record[1]) %>
+<% end %>
+<% @deleted_records.each do |record| %>
+  <%= sprintf("%-20.30s%-26.26s-26.26s-26.26s\r\n", 'No Longer in CMR', record[2].upcase,record[0],record[1]) %>
+<% end %>

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,6 @@ every 1.day, at: '4:00 am' do
   rake 'keyword_validation_cron:validate_keywords'
 end
 set :output, 'log/refresh_records.log'
-#every 1.day, at: '3:00 am' do
-every 15.minutes do
+every 1.day, at: '3:00 am' do
   rake 'refresh_records_cron:refresh_records'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,3 +21,7 @@ set :output, 'log/keyword_validation.log'
 every 1.day, at: '4:00 am' do
   rake 'keyword_validation_cron:validate_keywords'
 end
+set :output, 'log/refresh_records.log'
+every 1.day, at: '3:00 am' do
+  rake 'refresh_records_cron:refresh_records'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,6 +22,7 @@ every 1.day, at: '4:00 am' do
   rake 'keyword_validation_cron:validate_keywords'
 end
 set :output, 'log/refresh_records.log'
-every 1.day, at: '3:00 am' do
+#every 1.day, at: '3:00 am' do
+every 15.minutes do
   rake 'refresh_records_cron:refresh_records'
 end

--- a/lib/tasks/refresh_records.rake
+++ b/lib/tasks/refresh_records.rake
@@ -6,6 +6,9 @@ namespace :refresh_records_cron do
     unless user.nil?
       current_user = User.find_by(uid: user)
       added_records, deleted_records, failed_records = Cmr.update_collections(current_user)
+      added_records.sort_by! { |record| record[2] }
+      deleted_records.sort_by! { |record| record[2] }
+      failed_records.sort_by! { |record| record[2] }
       RefreshRecordsMailer.release_refreshed_records([current_user.email], added_records, failed_records, deleted_records).deliver_now
     end
   end

--- a/lib/tasks/refresh_records.rake
+++ b/lib/tasks/refresh_records.rake
@@ -1,0 +1,12 @@
+require 'dotenv/tasks'
+desc 'refresh records'
+namespace :refresh_records_cron do
+  task refresh_records: :environment do
+    user = ENV['cron_admin_user']
+    unless user.nil?
+      current_user = User.find_by(uid: user)
+      added_records, deleted_records, failed_records = Cmr.update_collections(current_user)
+      RefreshRecordsMailer.release_refreshed_records([current_user.email], added_records, failed_records, deleted_records).deliver_now
+    end
+  end
+end


### PR DESCRIPTION
The purpose of this PR is to refresh records nightly, so any new revisions that come in, especially when records are in review will be evident.