### PR TITLE
CMRARC-809: Adding pumad to the Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'simplecov', :require => false, :group => :test
 
 #using puma server instead of webBrick
 gem 'puma', '~> 6.3.1'
+gem 'puma-daemon', require: false
 #base authentication gem
 gem 'devise'
 #setting user permissions for pages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1647,6 +1647,9 @@ GEM
     public_suffix (5.0.1)
     puma (6.3.1)
       nio4r (~> 2.0)
+    puma-daemon (0.3.2)
+      puma (>= 5.0)
+      rack
     racc (1.7.1)
     rack (2.2.8)
     rack-protection (3.0.6)
@@ -1837,6 +1840,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 6.3.1)
+  puma-daemon
   rails (~> 6.1)
   rails-controller-testing
   rails-erd

--- a/README.md
+++ b/README.md
@@ -174,3 +174,6 @@ Note: The above work-around is not necessary on GET requests, only POST, PUT, an
 See [https://bugs.earthdata.nasa.gov/browse/CMRARC-484] and [https://github.com/rails/rails/issues/24257]
 for more details.
 
+## Issues with running puma in daemon mode.
+Starting in version 5, puma no longer supports -d.   In order to run it in daemon mode, the 'puma-daemon' gem was added.   Example to launch: `RAILS_ENV=sit bundle exec pumad -C config/puma.rb -e sit`
+It is also worth noting that this does not work on a MAC without setting the following env variable: `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`, as noted here: https://github.com/rails/rails/issues/38560


### PR DESCRIPTION
To run in daemon mode in the Mac, you'll need to set this env var:
export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES

Not necessary when just running straight puma though (e.g., rails s)