### PR TITLE
CMRARC-384: Open new tab when clicking ‘UMM-JSON’

### DIFF
--- a/app/views/reviews/_navbar.html.erb
+++ b/app/views/reviews/_navbar.html.erb
@@ -58,7 +58,7 @@
       <% end %>
 
       <p class="format_links">SOURCE FILES :
-        <a class="format_link" href="<%= record.umm_json_link %>" download>UMM-JSON</a> |
+        <a class="format_link" href="<%= record.umm_json_link %>" download target="_blank">UMM-JSON</a> |
         <a class="format_link" href="<%= record.native_link %>" download>NATIVE</a></p>
     <% else %>
       <p>FORMAT : GRANULE <%= record.format == 'umm_json' ? 'umm-g; version='+(record.format_version || "n/a") : 'echo10' %></p>


### PR DESCRIPTION
When reviewing a file, clicking UMM_JSON will open a new tab. Added target='_blank' to <a> tag. 

<img width="638" alt="Screenshot 2024-04-19 at 9 37 45 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/cfcd6711-8cba-44a0-b41e-146731bee058">
