### PR TITLE
CMRARC-582: Turn back on the validation of closed records to ensure integrity

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -36,13 +36,6 @@ module  RecordHelper
   # checks if the granule can be associated
   # note if the checks fail, the caller should not associate the granule record to the collection.
   def can_associate_granule?(granule_record, collection_state)
-    # it is ok to associate granule records without checks if in open or in_arc_review
-    # May 7 2020: Added status 'closed', this is a temporary change to allow users to associate
-    # closed records until arc team either finishes reviewing all legacy imported records or
-    # we fix the bug that is preventing users from marking all colors for a record.
-    # return [true, nil] if %w(open in_arc_review closed).include?(collection_state)
-
-    #  turn back on the validation of closed records to ensure integrity.
     return [true, nil] if %w(open in_arc_review).include?(collection_state)
 
     success = true

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -40,7 +40,10 @@ module  RecordHelper
     # May 7 2020: Added status 'closed', this is a temporary change to allow users to associate
     # closed records until arc team either finishes reviewing all legacy imported records or
     # we fix the bug that is preventing users from marking all colors for a record.
-    return [true, nil] if %w(open in_arc_review closed).include?(collection_state)
+    # return [true, nil] if %w(open in_arc_review closed).include?(collection_state)
+
+    #  turn back on the validation of closed records to ensure integrity.
+    return [true, nil] if %w(open in_arc_review).include?(collection_state)
 
     success = true
     messages = []

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -37,7 +37,7 @@ module  RecordHelper
   # note if the checks fail, the caller should not associate the granule record to the collection.
   def can_associate_granule?(granule_record, collection_state)
     return [true, nil] if %w(open in_arc_review).include?(collection_state)
-   
+
     success = true
     messages = []
     if %w(closed).include?(collection_state)
@@ -45,7 +45,6 @@ module  RecordHelper
       success = false
       return [success, messages]
     end
-    [success, messages]
     unless granule_record.color_coding_complete?
       messages << 'Not all columns in the associated granule have been flagged with a color!'
       success = false

--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -37,9 +37,15 @@ module  RecordHelper
   # note if the checks fail, the caller should not associate the granule record to the collection.
   def can_associate_granule?(granule_record, collection_state)
     return [true, nil] if %w(open in_arc_review).include?(collection_state)
-
+   
     success = true
     messages = []
+    if %w(closed).include?(collection_state)
+      messages << "Can't associate collection to granule. Only open and in review collection records can be associated."
+      success = false
+      return [success, messages]
+    end
+    [success, messages]
     unless granule_record.color_coding_complete?
       messages << 'Not all columns in the associated granule have been flagged with a color!'
       success = false

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -126,7 +126,7 @@ class RecordsControllerTest < ActionController::TestCase
       sign_in(user)
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
-      Record.any_instance.stubs(close!: true)
+      Record.any_instance.stubs(close!: false)
       record = Record.find(1)
 
       post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16 }

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -121,6 +121,20 @@ class RecordsControllerTest < ActionController::TestCase
       assert_redirected_to collection_path(id: 1, record_id: record.id)
     end
 
+    it 'displays a failure message when granule association fails' do
+      user = User.find_by(email: 'abaker@element84.com')
+      sign_in(user)
+      stub_urs_access(user.uid, user.access_token, user.refresh_token)
+
+      Record.any_instance.stubs(close!: true)
+      record = Record.find(1)
+
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16 }
+
+      assert_equal 'Failed to associate granule.', flash[:notice]
+      assert_redirected_to collection_path(id: 1, record_id: record.id)
+    end
+
     it 'roundtrip release to daac both a collection and assoc granule record and then revert it' do
       user = User.find_by(role: 'admin')
       sign_in(user)

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -126,10 +126,10 @@ class RecordsControllerTest < ActionController::TestCase
       sign_in(user)
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
-      Record.any_instance.stubs(:associate_granule_to_collection).returns(false)
+      Record.any_instance.stubs(close!: true)
       record = Record.find(1)
-
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 13 }
+      
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: valid_granule_id }
 
       assert_equal 'Failed to associate granule.', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -127,17 +127,13 @@ class RecordsControllerTest < ActionController::TestCase
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
       Record.any_instance.stubs(close!: true)
-      Record.stubs(:find).with(1).returns(Record.new(id: 1))
+      record = Record.find(1)
 
-      Record.stubs(:find_by).with(id: 'non_existent_granule_id').returns(nil)
+      Record.stubs(:associate_granule_to_collection).returns(false)
 
-      stubbed_success = false
-      stubbed_messages = ['An error occurred while associating granule.']
-      RecordsController.any_instance.stubs(:can_associate_granule?).returns([stubbed_success, stubbed_messages])
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: false }
 
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 'non_existent_granule_id' }
-
-      assert_equal 'Failed to associate granule.', flash[:notice]
+      assert_equal 'An error occurred associating granule to the collection', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)
     end
 

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -126,10 +126,10 @@ class RecordsControllerTest < ActionController::TestCase
       sign_in(user)
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
-      Record.any_instance.stubs(success?: false)
+      Record.any_instance.stubs(:associate_granule_to_collection).returns(false)
       record = Record.find(1)
 
-      post :complete, params: { id: record.id }
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16 }
 
       assert_equal 'Failed to associate granule.', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -127,12 +127,12 @@ class RecordsControllerTest < ActionController::TestCase
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
       Record.any_instance.stubs(close!: true)
-      record = Record.find(1)
+      record = Record.find(15)
 
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 3 }
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16  }
 
-      assert_equal 'An error occurred associating granule to the collection', flash[:notice]
-      assert_redirected_to collection_path(id: 1, record_id: record.id)
+      assert_equal "Can't associate collection to granule. Only open and in review collection records can be associated.", flash[:alert]
+      assert_redirected_to collection_path(id: 7, record_id: record.id)
     end
 
     it 'roundtrip release to daac both a collection and assoc granule record and then revert it' do

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -126,10 +126,10 @@ class RecordsControllerTest < ActionController::TestCase
       sign_in(user)
       stub_urs_access(user.uid, user.access_token, user.refresh_token)
 
-      Record.any_instance.stubs(close!: false)
+      Record.any_instance.stubs(success?: false)
       record = Record.find(1)
 
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16 }
+      post :complete, params: { id: record.id }
 
       assert_equal 'Failed to associate granule.', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -129,9 +129,7 @@ class RecordsControllerTest < ActionController::TestCase
       Record.any_instance.stubs(close!: true)
       record = Record.find(1)
 
-      Record.stubs(:associate_granule_to_collection).returns(false)
-
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: false }
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 3 }
 
       assert_equal 'An error occurred associating granule to the collection', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -129,7 +129,7 @@ class RecordsControllerTest < ActionController::TestCase
       Record.any_instance.stubs(:associate_granule_to_collection).returns(false)
       record = Record.find(1)
 
-      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 16 }
+      post :associate_granule_to_collection, params: { id: record.id, associated_granule_value: 13 }
 
       assert_equal 'Failed to associate granule.', flash[:notice]
       assert_redirected_to collection_path(id: 1, record_id: record.id)


### PR DESCRIPTION
Previous ticket [CMRARC-579](https://bugs.earthdata.nasa.gov/browse/CMRARC-579) to remove the blocker aspect of this ticket by allowing users to assoc granules from records "closed" even if they didn't pass validation checks (like all fields colored), or only 1 review.

So now CMRARC-582 is to turn back on the validation of closed collection records associating with a granule record to ensure integrity.

I am using this closed collection record as an example because it has only 1 reviewer C43677727-LARC/4

CURRENTLY THE VALIDATION OF CLOSED RECORDS IS BEING TURNED OFF; THEREFORE, WHEN A USER TRIES TO ASSOCIATE A CLOSED COLLECTION RECORD WITH A GRANULE RECORD, THE VALIDATION FOR "Failed to associate granule - Not all columns in the associated granule have been flagged with a color! The associated granule needs two completed reviews." IS OFF-->NO FLASH WITH ERROR MESSAGE-->which allows user to associate successfully.

<img width="996" alt="Screenshot 1-search for a closed collection record" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/b71138d1-b7ea-4dd5-be3d-36fa3da6742e">
<img width="1038" alt="Screenshot 2-Select Granule Rev ID" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/c3d6e5e0-fb35-4c5b-add7-94c974874cef">

<img width="1128" alt="Screenshot 3-successfully associated message" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/2173a3cd-ee6b-46f8-8422-2ca3b60f5471">

NOW THE VALIDATION OF CLOSED RECORDS IS BEING TURNED BACK ON  FOR CMRARC-582-->FLASH WITH ERROR MESSAGE-->Can't associate collection to granule.  Only open and in review collection records can be associated.

<img width="1605" alt="Screenshot 2024-04-26 at 2 54 52 PM" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/34471651-741a-4058-ae0b-7763b7d15b34">



