### PR TITLE
CMRARC-504: Add Link to Dashboard's User Guide

### DIFF
--- a/app/assets/stylesheets/common/_base.scss
+++ b/app/assets/stylesheets/common/_base.scss
@@ -33,14 +33,7 @@ button {
 
 //overwriting the normal eui menu styles.
 .eui-menu.menu_override {
-  // position:absolute;
-  // top:8px;
-  // right:25px;
-
-
   .menu_link {
-    padding-top:23px;
-    min-height: 70px;
     &:hover {
       background-color: $sky-blue;
     }
@@ -71,21 +64,19 @@ button {
   display: -webkit-flex; /* Safari */
   -webkit-justify-content: space-between; /* Safari 6.1+ */
   display: flex;
-  justify-content: space-between;
-
   color: white;
 
   background-color: $blue-dark;
   width:100%;
   min-height: 80px;
+  padding: 1em 2em;
+  align-items: center;
 
   .header_title {
     display: flex;
     flex-direction: column;
     letter-spacing: 0.5px;
     font-weight: 500;
-    padding-top: 25px;
-    padding-left: 40px;
     p {
       position: relative;
       bottom: 1px;
@@ -96,8 +87,8 @@ button {
   }
 
   .header_menu {
-    margin-top: 9px;
-    margin-right: 40px;
+    display: flex;
+    flex-direction: column;
   }
 
   h3 {

--- a/app/assets/stylesheets/components/_user_info_box.scss
+++ b/app/assets/stylesheets/components/_user_info_box.scss
@@ -4,7 +4,7 @@
   #user-info {
     @include row();
     display: inline-flex;
-    margin-left: 66%;
+    margin-left: 82%;
     font-size: 0.8em;
     margin-bottom: 1em;
 

--- a/app/assets/stylesheets/components/_user_info_box.scss
+++ b/app/assets/stylesheets/components/_user_info_box.scss
@@ -4,30 +4,25 @@
   #user-info {
     @include row();
     display: inline-flex;
-    margin-left: 65%;
+    margin-left: 66%;
     font-size: 0.8em;
-    background-color: lighten($ocean-blue, 10%);
-    padding: .2em .6em .3em .6em;
-    border-radius: 5px;
     margin-bottom: 1em;
 
-    #profile-link {
-      .prof-link-container {
-        margin-top: .1em;
-      }
-
-      .hoverOver {
-        color: lighten($dolphin-grey, 30%);
-      }
-
-      #dropdown-caret {
-        transform: rotate(0deg);
+    .users-guide-link {
+      color: white;
+      padding: .2em .6em .3em .6em;
+      &:hover {
+        color: $midnight-blue;
       }
     }
+    .prof-link-container {
+      background-color: lighten($ocean-blue, 10%);
+      padding: .2em .6em .3em .6em;
+      border-radius: 5px;
+    }
   
-
-     .eui-badge--sm {
-      vertical-align: middle;
+    .eui-badge--sm {
+      margin-left: .2em;
     }
   
   }

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -8,9 +8,6 @@
 
   <div class="header_menu">
   <section id="user-info">
-  <%= link_to "https://wiki.earthdata.nasa.gov/pages/viewpage.action?spaceKey=CMR&title=CMR+Metadata+Curation+Dashboard+User+Documentation", class: "users-guide-link", target: "_blank" do %>
-    <p>User&apos;s Guide</p>
-  <% end %>
       <div class="prof-link-container">
           <div><strong><%= current_user.name %></strong>
             <span class="eui-badge--sm daac"><%= current_user.role %></span>
@@ -61,6 +58,13 @@
               </ul>
           </li>
         <% end %>
+
+        <li>
+        <%= link_to "https://wiki.earthdata.nasa.gov/pages/viewpage.action?spaceKey=CMR&title=CMR+Metadata+Curation+Dashboard+User+Documentation", class: "menu_link header_button", target: "_blank" do %>
+          <i class="fa fa-question-circle"></i>
+          <p>User&apos;s Guide</p>
+        <% end %>
+        </li>
 
         <li>
           <%= link_to destroy_user_session_path, method: :get, class: "menu_link header_button" do %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -7,13 +7,16 @@
   </div>
 
   <div class="header_menu">
-    <section id="user-info">
-        <div class="prof-link-container">
-            <div><strong><%= current_user.name %></strong>
-                 <span class="eui-badge--sm daac"><%= current_user.role %></span>
-            </div>
-        </div>
-    </section>
+  <section id="user-info">
+  <%= link_to "https://wiki.earthdata.nasa.gov/pages/viewpage.action?spaceKey=CMR&title=CMR+Metadata+Curation+Dashboard+User+Documentation", class: "users-guide-link", target: "_blank" do %>
+    <p>User&apos;s Guide</p>
+  <% end %>
+      <div class="prof-link-container">
+          <div><strong><%= current_user.name %></strong>
+            <span class="eui-badge--sm daac"><%= current_user.role %></span>
+          </div>
+      </div>
+  </section>
     <nav class="eui-menu menu_override">
       <ul>
         <li>


### PR DESCRIPTION
In this ticket, I added User's Guide documentation to the static header of the dashboard. This link opens up in a new tab. To get this to line up the way we would like I ended up cleaning up a bit of the css. Below is a screenshot of the previous static header. 
<img width="1674" alt="Screenshot 2024-04-29 at 2 00 15 PM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/09294805-7b45-40ec-b4d3-d7dda8913d75">

Here is the new static header with my edits. 
<img width="1709" alt="Screenshot 2024-04-30 at 9 02 49 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/822842d6-1de2-4782-a70d-c4e060dc2596">


