### PR TITLE
CMRARC-813: Removing metric data when irrelevant

### DIFF
--- a/app/models/multi_record_csv.rb
+++ b/app/models/multi_record_csv.rb
@@ -61,8 +61,10 @@ class MultiRecordCsv
               end
             end
 
-            METRIC_FIELDS.each do |field|
-              collection_column_titles.push(field)
+            if full_report
+              METRIC_FIELDS.each do |field|
+                collection_column_titles.push(field)
+              end
             end
 
             csv << ['Collection'] + Array.new(collection_column_titles.count - 1) + ['Granule']
@@ -90,8 +92,10 @@ class MultiRecordCsv
                     end
                   end
 
-                  METRIC_FIELDS.each do |field|
-                    granule_column_titles.push(field)
+                  if full_report
+                    METRIC_FIELDS.each do |field|
+                      granule_column_titles.push(field)
+                    end
                   end
               
                   record_line += generate_csv_line(granule_record, granule_column_titles, false, full_report)
@@ -150,7 +154,11 @@ class MultiRecordCsv
       end
     end
 
-    line + metric_data_array(record)
+    if full_report_boolean
+      line + metric_data_array(record)
+    else 
+      line
+    end
   end
 
   def metric_data_array(record)


### PR DESCRIPTION
This is an edit that has been requested for the previous pull request. The only change is that when a user requests to export recommendations, the metric data is removed from the spreadsheet. 

Old Version: 
![Screenshot 2024-04-30 at 1 28 23 PM](https://github.com/nasa/cmr-metadata-review/assets/135638667/e8208652-72c9-4187-ab3d-059c87c36a41)

New Version:
![Screenshot 2024-04-30 at 1 28 47 PM](https://github.com/nasa/cmr-metadata-review/assets/135638667/b2a9570f-899a-4367-aebd-ecfc0bd1e924)
