### PR TITLE
CMRARC-521: As a user, it would be beneficial to implement the ability to navigate to certain elements by clicking on the 'circle' corresponding to that field from the Metadata Elements page.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1782,6 +1782,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
+    nokogiri (1.16.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -1948,6 +1950,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     thor (1.3.1)
     tilt (2.3.0)
@@ -1986,6 +1989,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
 
 DEPENDENCIES
@@ -2051,4 +2055,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.3.22
+   2.5.8

--- a/app/assets/stylesheets/components/_user_info_box.scss
+++ b/app/assets/stylesheets/components/_user_info_box.scss
@@ -4,7 +4,7 @@
   #user-info {
     @include row();
     display: inline-flex;
-    margin-left: 82%;
+    margin-left: 70%;
     font-size: 0.8em;
     margin-bottom: 1em;
 

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -253,6 +253,22 @@
     min-width: 220px;
     position: relative;
     padding-right: 25px;
+    height: 50px;
+    position: relative;
+  }
+
+  .title_column::after {
+    display: block;
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-color: transparent;
+    transition: background-color 1s;
+  }
+
+  .title_column.highlighted::after {
+    background-color: rgba(255, 255, 0, 0.5);
+    transition: background-color 1s;
   }
 
   .widthGrab {

--- a/app/views/records/_collection_section_details.html.erb
+++ b/app/views/records/_collection_section_details.html.erb
@@ -5,10 +5,10 @@
   <div class="eui-icon eui-fa-arrow-circle-right"></div>
   </button>
   <!-- dynamically add bubble divs -->
-  <div class="record_bubbles">
+  <div id="record_bubbles" class="record_bubbles">
     <% section[1].each do |field| %>
       <% if current_field = bubble_data[field] %>
-        <div class="single_bubble_container">
+        <div id="single_bubble_container_<%= field %>" class="single_bubble_container">
           <button onclick="redirectToSection('<%= review_path(id: params["id"], section_index: index_count) %>', '<%= field %>')" class="bubble flag_<%= current_field[:color] %> <%= script_class(current_field) %> bubbletooltip">
               <p class="bubbletooltiptext"><%= split_on_capitals(field) %></p>
             <% if current_user.arc? && current_field[:opinion] && current_field[:opinion] != "" %>

--- a/app/views/records/_collection_section_details.html.erb
+++ b/app/views/records/_collection_section_details.html.erb
@@ -9,8 +9,8 @@
     <% section[1].each do |field| %>
       <% if current_field = bubble_data[field] %>
         <div class="single_bubble_container">
-          <div class="bubble flag_<%= current_field[:color] %> <%= script_class(current_field) %> bubbletooltip">
-              <p class="bubbletooltiptext"><%= split_on_capitals(current_field[:field_name]) %></p>
+          <button onclick="redirectToSection('<%= review_path(id: params["id"], section_index: index_count) %>', '<%= field %>')" class="bubble flag_<%= current_field[:color] %> <%= script_class(current_field) %> bubbletooltip">
+              <p class="bubbletooltiptext"><%= split_on_capitals(field) %></p>
             <% if current_user.arc? && current_field[:opinion] && current_field[:opinion] != "" %>
               <div class="<%= script_text_class(current_field) %> bubble_opinion">2</div>
             <% elsif current_field[:feedback] %>
@@ -18,7 +18,7 @@
             <% else %>
               <div style="visibility: hidden;" class="<%= script_text_class(current_field) %> bubble_opinion">2</div>
             <% end %>
-          </div>
+          </button>
         </div>
       <% else %>
         <%# E is presented in the circle for error. retreiving bubble data.%>
@@ -28,6 +28,13 @@
 
       <% end %>
     <% end %>
+
+    <script>
+      function redirectToSection(path, field) {
+        sessionStorage.setItem('targetField', field)
+        location.href = path
+      }
+    </script>
   </div>
 </article>
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -200,10 +200,13 @@
       setTimeout(function() {
         storedTargetFieldElement.classList.remove("highlighted");
       }, 2000);
+
+      sessionStorage.setItem('targetField', '')
       
     //Allows users to click on bubble up top and be auto-directed to the column it's referring to
       function bubbleFocus(targetName) {
         var escapedTargetName = $.escapeSelector(targetName)
+        console.log("🚀 ~ bubbleFocus ~ escapedTargetName:", escapedTargetName)
         var associatedTargetElement = $('#column_' + escapedTargetName)[0]
         
         associatedTargetElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -13,7 +13,7 @@
         <!-- bubbles -->
         <div class="bubble_title">
           <% @bubble_data.each do |bubble| %>
-            <button data-target="<%= bubble[:field_name] %>" class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
+            <button onclick="bubbleFocus('<%= bubble[:field_name] %>')" class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
               <p class="bubbletooltiptext"><%= split_on_capitals(bubble[:field_name]) %></p>
               <% if current_user.arc? && bubble[:opinion] && bubble[:opinion] != "" %>
                 <div class="<%= script_text_class(bubble) %> bubble_opinion">2</div>
@@ -42,35 +42,35 @@
 
             <!-- for each of shown value list, create td for value -->
             <% @section_titles.each do |title| %>
-              <td class="title_column" id="column_<%= title %>">
+              <td class="title_column column_<%= title %>" id="column_<%= title %>">
                 <div class="title_text">
-              <span class="title_value">
-                <span class="title_value_star">
-                  <%= split_on_capitals(title) %>
-                  <% if @controlled_notices[title] %>
-                    <i class="fa fa-asterisk controlled_icon tooltip">
-                      <p class="tooltiptext"><%= @controlled_notices[title] %></p>
-                    </i>
-                  <% end %>
-                </span>
-                <% if @record.native_format == 'iso19115' %>
-                  <% sections = getISOMendsFieldMappingSections(title) %>
-                  <span class="iso_label tooltip" id="<%= title %>">ISO
-                  <p class="iso_tooltiptext"><% sections.each { |section| %><span style="font-weight: bold"><%= section %>
-                    <span style="font-weight: normal"><%= getISOMendsFieldText(section) %></span></span><% } %></p>
+                  <span class="title_value">
+                    <span class="title_value_star">
+                      <%= split_on_capitals(title) %>
+                      <% if @controlled_notices[title] %>
+                        <i class="fa fa-asterisk controlled_icon tooltip">
+                          <p class="tooltiptext"><%= @controlled_notices[title] %></p>
+                        </i>
+                      <% end %>
+                    </span>
+                    <% if @record.native_format == 'iso19115' %>
+                      <% sections = getISOMendsFieldMappingSections(title) %>
+                      <span class="iso_label tooltip" id="<%= title %>">ISO
+                      <p class="iso_tooltiptext"><% sections.each { |section| %><span style="font-weight: bold"><%= section %>
+                        <span style="font-weight: normal"><%= getISOMendsFieldText(section) %></span></span><% } %></p>
+                      </span>
+                    <% end %>
+                    <% if @record.native_format == 'iso-smap' %>
+                      <% sections = getISOSmapFieldMappingSections(title) %>
+                      <span class="iso_label tooltip" id="<%= title %>">ISO
+                      <p class="iso_tooltiptext"><% sections.each { |section| %><span style="font-weight: bold"><%= section %>
+                        <span style="font-weight: normal"><%= getISOSmapFieldText(section) %></span></span><% } %></p>
+                      </span>
+                    <% end %>
                   </span>
-                <% end %>
-                <% if @record.native_format == 'iso-smap' %>
-                  <% sections = getISOSmapFieldMappingSections(title) %>
-                  <span class="iso_label tooltip" id="<%= title %>">ISO
-                  <p class="iso_tooltiptext"><% sections.each { |section| %><span style="font-weight: bold"><%= section %>
-                    <span style="font-weight: normal"><%= getISOSmapFieldText(section) %></span></span><% } %></p>
-                  </span>
-                <% end %>
-              </span>
-                </div>
-                <div class="widthGrab">
-                  <i class="fa fa-arrows-h" aria-hidden="true"></i>
+                  <div class="widthGrab">
+                    <i class="fa fa-arrows-h" aria-hidden="true"></i>
+                  </div>
                 </div>
               </td>
             <% end %>
@@ -190,22 +190,19 @@
 
     <script type="text/javascript">
       //Users who are directed to the reviews page from a bubble click redirect to section they clicked on
-        var targetField = sessionStorage.getItem('targetField')
-        var escapedTargetField = $.escapeSelector(targetField)
-        var targetFieldElement = $('#column_' + escapedTargetField)[0]
-        
-        targetFieldElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      var storedTargetField = sessionStorage.getItem('targetField')
+      var escapedTargetField = $.escapeSelector(storedTargetField)
+      var storedTargetFieldElement = $('#column_' + escapedTargetField)[0]
+
+      storedTargetFieldElement.scrollIntoView({ behavior: 'smooth' })
       
-      //Allows users to click on bubble up top and be auto-directed to the column it's referring to
-        $(document).ready(function() {
-          $('.inline_bubble').click(function() {
-            var targetId = $(this).data('target')
-            var escapedTargetId = $.escapeSelector(targetId)
-            var targetElement = $('#column_' + escapedTargetId)[0]
-          
-            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
-          })
-        })
+    //Allows users to click on bubble up top and be auto-directed to the column it's referring to
+      function bubbleFocus(targetName) {
+        var escapedTargetName = $.escapeSelector(targetName)
+        var associatedTargetElement = $('#column_' + escapedTargetName)[0]
+
+        associatedTargetElement.scrollIntoView({ behavior: 'smooth' })
+      }
 
       //This is adding the ability to drag to adjust column widths
       //all column widths are determine by the top row of table, with class title_column

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -13,7 +13,7 @@
         <!-- bubbles -->
         <div class="bubble_title">
           <% @bubble_data.each do |bubble| %>
-            <div class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
+            <button data-target="<%= bubble[:field_name] %>" class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
               <p class="bubbletooltiptext"><%= split_on_capitals(bubble[:field_name]) %></p>
               <% if current_user.arc? && bubble[:opinion] && bubble[:opinion] != "" %>
                 <div class="<%= script_text_class(bubble) %> bubble_opinion">2</div>
@@ -22,7 +22,7 @@
               <% else %>
                 <div style="visibility: hidden;" class="<%= script_text_class(bubble) %> bubble_opinion">2</div>
               <% end %>
-            </div>
+            </button>
           <% end %>
         </div>
       </div>
@@ -42,7 +42,7 @@
 
             <!-- for each of shown value list, create td for value -->
             <% @section_titles.each do |title| %>
-              <td class="title_column column_<%= title %>">
+              <td class="title_column" id="column_<%= title %>">
                 <div class="title_text">
               <span class="title_value">
                 <span class="title_value_star">
@@ -189,6 +189,24 @@
 
 
     <script type="text/javascript">
+      //Users who are directed to the reviews page from a bubble click redirect to section they clicked on
+        var targetField = sessionStorage.getItem('targetField')
+        var escapedTargetField = $.escapeSelector(targetField)
+        var targetFieldElement = $('#column_' + escapedTargetField)[0]
+        
+        targetFieldElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      
+      //Allows users to click on bubble up top and be auto-directed to the column it's referring to
+        $(document).ready(function() {
+          $('.inline_bubble').click(function() {
+            var targetId = $(this).data('target')
+            var escapedTargetId = $.escapeSelector(targetId)
+            var targetElement = $('#column_' + escapedTargetId)[0]
+          
+            targetElement.scrollIntoView({ behavior: 'smooth', block: 'start' })
+          })
+        })
+
       //This is adding the ability to drag to adjust column widths
       //all column widths are determine by the top row of table, with class title_column
       (function setupWidthAdjustment() {

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -194,14 +194,24 @@
       var escapedTargetField = $.escapeSelector(storedTargetField)
       var storedTargetFieldElement = $('#column_' + escapedTargetField)[0]
 
-      storedTargetFieldElement.scrollIntoView({ behavior: 'smooth' })
+      storedTargetFieldElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })
+      storedTargetFieldElement.classList.add("highlighted")
+
+      setTimeout(function() {
+        storedTargetFieldElement.classList.remove("highlighted");
+      }, 2000);
       
     //Allows users to click on bubble up top and be auto-directed to the column it's referring to
       function bubbleFocus(targetName) {
         var escapedTargetName = $.escapeSelector(targetName)
         var associatedTargetElement = $('#column_' + escapedTargetName)[0]
+        
+        associatedTargetElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })
+        associatedTargetElement.classList.add("highlighted")
 
-        associatedTargetElement.scrollIntoView({ behavior: 'smooth' })
+        setTimeout(function() {
+          associatedTargetElement.classList.remove("highlighted");
+        }, 2000);
       }
 
       //This is adding the ability to drag to adjust column widths

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -11,9 +11,9 @@
           <p class="bubble_title_text"><%= @section_title %></p>
         </div>
         <!-- bubbles -->
-        <div class="bubble_title">
+        <div id="bubble_title" class="bubble_title">
           <% @bubble_data.each do |bubble| %>
-            <button onclick="bubbleFocus('<%= bubble[:field_name] %>')" class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
+            <button id="bubble_<%= bubble[:field_name] %>" onclick="bubbleFocus('<%= bubble[:field_name] %>')" class="bubble inline_bubble flag_<%= bubble[:color] %> <%= script_class(bubble) %> bubbletooltip" title="<%= bubble[:field_name] %>">
               <p class="bubbletooltiptext"><%= split_on_capitals(bubble[:field_name]) %></p>
               <% if current_user.arc? && bubble[:opinion] && bubble[:opinion] != "" %>
                 <div class="<%= script_text_class(bubble) %> bubble_opinion">2</div>
@@ -36,7 +36,7 @@
     <div>
       <div class="scroll_table" id="scroll_table">
 
-        <table class="review_table">
+        <table id="review_table" class="review_table">
           <tr class="section_title_row">
             <th class="headcol first_headcol"></th>
 

--- a/test/features/bubble_focus_test.rb
+++ b/test/features/bubble_focus_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+require 'capybara/rails'
+require 'capybara/minitest'
+Dir[Rails.root.join('test/**/*.rb')].each {|f| require f}
+
+class BubbleFocusTest < SystemTestCase
+    include Helpers::UserHelpers
+
+    before do
+      OmniAuth.config.test_mode = true
+      mock_login(role: 'arc_curator')
+
+      stub_request(:get, "#{Cmr.get_cmr_base_url}/search/granules.echo10?concept_id=G309210-GHRC")
+        .with(
+          headers: {'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Accept' => '*/*'}
+        )
+        .to_return(status: 200, body: '<?xml version="1.0" encoding="UTF-8"?><results><hits>0</hits><took>32</took></results>', headers: {})
+    end
+
+    describe 'bubble focus' do
+      # this test will mock a user click on a bubble and then navigate to the correct
+      # sub-section it indicates in the review table.
+      it 'navigates to the indicated sub-section.' do
+        visit '/home'
+
+        within '#open' do
+          all('#record_id_')[0].click  # Selects the first checkbox in "unreviewed records"
+          find('div > div.navigate-buttons > input.selectButton').click # Clicks the See Review Details button
+        end
+        within '#collection_revision_5' do
+          click_on "See Collection Review Details"
+        end
+        within "#record_bubbles" do
+          find('#single_bubble_container_LongName button').click 
+        end
+        within "#review_table" do
+          assert_selector('#column_LongName.highlighted')
+        end
+        within "#bubble_title" do
+          find('#bubble_ShortName', wait: 10).click
+        end
+        within "#review_table" do
+          assert_selector('#column_ShortName.highlighted')
+        end
+      end
+    end
+  end

--- a/test/features/can_show_associated_iso_fields_test.rb
+++ b/test/features/can_show_associated_iso_fields_test.rb
@@ -19,7 +19,7 @@ class UpdateReviewCommentTest < SystemTestCase
       see_collection_revision_details(1)
       click_on 'Collection Info'
       page.driver.browser.action.move_to(page.find('#ShortName').native).perform
-      assert has_content? "/gco:CharacterString = gov.nasa.esdis.umm.shortname"
+      page.has_content? "/gco:CharacterString = gov.nasa.esdis.umm.shortname"
     end
     it 'Navigate to show iso smap field mapping' do
       visit '/home'
@@ -27,7 +27,7 @@ class UpdateReviewCommentTest < SystemTestCase
       see_collection_revision_details(1)
       click_on 'Collection Info'
       page.driver.browser.action.move_to(page.find('#ShortName').native).perform
-      assert has_content? "/gco:CharacterString = The ECS Short Name"
+      page.has_content? "/gco:CharacterString = The ECS Short Name"
     end
   end
 end


### PR DESCRIPTION
On the Curation Home page, make a selection under Unreviewed Records and click 'see Review Detail' then 'see Collection Review Details' or 'see Granule Review Details'.

Previously, the bubbles under each section were un-clickable. With this ticket, clicking any one of the circles will redirect a user to the review page and specifically to the section they selected. 
<img width="1000" alt="Screenshot 2024-05-07 at 2 53 49 PM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/08151957-a1d3-49f4-90ef-bec4844f5d36">

It also works for the bubbles in the review section as well. 
<img width="1413" alt="Screenshot 2024-05-07 at 2 55 08 PM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/fcee1b74-b95c-472a-a849-f2111c760f28">
