### PR TITLE
CMRACR-843: Formatting for umm_json use case

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -100,19 +100,13 @@ class RecordsController < ApplicationController
 
     response_array = []
     response_records.each do |record|
-      if record.format == 'umm_json'
-        response_array.push({"id":record.id, "state":record.state, "concept_id": record[:concept_id],
-        "date_ingested": record[:date_ingested], format: 'umm-c',
-        "revision_id": record.revision_id, "short_name": record[:short_name],
-        "version": record.version_id, "no_completed_reviews": record.completed_reviews(record.reviews),
-        "no_second_reviews_requested": record_second_opinion_counts[record.id].to_i})
-      else 
-        response_array.push({"id":record.id, "state":record.state, "concept_id": record[:concept_id],
-        "date_ingested": record[:date_ingested], format: record[:format],
-        "revision_id": record.revision_id, "short_name": record[:short_name],
-        "version": record.version_id, "no_completed_reviews": record.completed_reviews(record.reviews),
-        "no_second_reviews_requested": record_second_opinion_counts[record.id].to_i})
-      end
+      record_format = (record[:format] == 'umm_json') ? 'umm-c' : record[:format]
+    
+      response_array.push({"id":record.id, "state":record.state, "concept_id": record[:concept_id],
+      "date_ingested": record[:date_ingested], format: record_format,
+      "revision_id": record.revision_id, "short_name": record[:short_name],
+      "version": record.version_id, "no_completed_reviews": record.completed_reviews(record.reviews),
+      "no_second_reviews_requested": record_second_opinion_counts[record.id].to_i})
     end
 
     count_result = ActiveRecord::Base.connection.exec_query(count_query)


### PR DESCRIPTION
Addressing an issue found in this ticket where umm_json was not accurate for the format. This is a specific use case where the format of umm_json files is actually umm-c. You can see this issue previously addressed in application_helper.rb line 132:

  def get_format_and_version(format, version)
    version = 'n/a' if version.nil?
    format == 'umm_json' ? "umm-c; version=#{version}" : format
  end

Before, this format said umm_json in the format column, this fix changes it so that it says umm-c. (Chris, I couldn't use the above function because it would have included the version # as well)

<img width="1050" alt="Screenshot 2024-05-09 at 1 54 43 PM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/d5744d4c-99f7-4d3a-a54d-0cf91b2be836">
