### PR TITLE
CMRARC-443: Change Message Viewed by User When Not Provisioned

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -23,7 +23,7 @@ class LoginController < Devise::OmniauthCallbacksController
     else
       redirect_to root_path
       if (@user.role.nil?)
-        flash.notice = "User is not provisioned with the proper ACLs.   Please contact the Earthdata Operations team."
+        flash.notice = "The user is not provisioned with the proper ACLs. Please contact User Support at support@earthdata.nasa.gov."
       else
         flash.notice = "Could not authenticate from Earthdata Login"
       end

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -50,13 +50,28 @@ class LoginControllerTest < ActionController::TestCase
       end
 
       it "should set flash notice when user role is nil" do
-        mock_normal_edl_user
 
-        User.any_instance.stubs(:role).returns(nil)
+        AclDao.any_instance.stubs(:get_role_and_daac).returns([nil, nil])
 
         post :urs, params: { provider: :urs }
 
         assert_equal "The user is not provisioned with the proper ACLs. Please contact User Support at support@earthdata.nasa.gov.", flash[:notice]
+      end
+
+      it "should set flash notice when CMR ACL request fails" do
+
+        stub_request(:get, "#{Cmr.get_cmr_base_url}/access-control/acls?page_num=1&page_size=2000&permitted_user=normaluser")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer accesstoken'
+            })
+          .to_return(status: 500)
+
+        post :urs, params: { provider: :urs }
+
+        assert_equal "Error retrieving ACLs from CMR for normaluser", flash[:notice]
       end
     end
 

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -50,8 +50,15 @@ class LoginControllerTest < ActionController::TestCase
       end
 
       it "should set flash notice when user role is nil" do
-
-        AclDao.any_instance.stubs(:get_role_and_daac).returns([nil, nil])
+        stub_request(:get, "#{Cmr.get_cmr_base_url}/access-control/acls?page_num=1&page_size=2000&permitted_user=normaluser")
+          .with(
+            headers: {
+              'Accept' => '*/*',
+              'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+              'Authorization' => 'Bearer accesstoken'
+            }
+          )
+          .to_return(status: 200, body: '{"hits":0,"took":661,"items":[]}', headers: {})
 
         post :urs, params: { provider: :urs }
 

--- a/test/controllers/login_controller_test.rb
+++ b/test/controllers/login_controller_test.rb
@@ -48,6 +48,16 @@ class LoginControllerTest < ActionController::TestCase
         after_count = User.count
         assert(after_count.must_equal(before_count + 1))
       end
+
+      it "should set flash notice when user role is nil" do
+        mock_normal_edl_user
+
+        User.any_instance.stubs(:role).returns(nil)
+
+        post :urs, params: { provider: :urs }
+
+        assert_equal "The user is not provisioned with the proper ACLs. Please contact User Support at support@earthdata.nasa.gov.", flash[:notice]
+      end
     end
 
   end


### PR DESCRIPTION
Currently, when a non-provisioned user tries to login to the Dashboard, they see the following message:

<img width="1409" alt="Screenshot 2024-05-13 at 3 32 52 PM" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/e4053d64-74f5-4ca4-92ff-f3de8824017b">




The new change is to update message which is displayed when a non-provisioned user attempts to login to the Dashboard.

<img width="1435" alt="Screenshot 2024-05-13 at 3 07 53 PM" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/679792ce-c330-41ec-bf2e-0090eb5b019f">
