### PR TITLE
CMRARC-386: As a DAAC curator, I want the collection review details legend to be updated to account for no recommendation

### DIFF
--- a/app/views/reviews/_legend.html.erb
+++ b/app/views/reviews/_legend.html.erb
@@ -55,6 +55,12 @@
         </div>
         <div class="legend_text">REVIEWED, ELEMENT ERROR</div>
       </div>
+      <div class="legend_flex_item">
+        <div class="bubble color_gray no_script">
+          <div style="visibility: hidden;">2</div>
+        </div>
+        <div class="legend_text">NO RECOMMENDATION</div>
+      </div>
     </div>
     <div class="legend_flex_row">
       <div class="legend_flex_item">


### PR DESCRIPTION
Currently: 

<img width="875" alt="Screenshot 2024-05-14 at 3 37 30 PM" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/41aecce3-4fc5-43f7-b2e1-0a8b81ed75a7">


New Change: Legend updated to include a grey circle to say 'No Recommendation' for fields where there is no recommendation made
<img width="980" alt="Screenshot 2024-05-14 at 3 06 30 PM" src="https://github.com/nasa/cmr-metadata-review/assets/63017465/233ad8aa-2bfc-4f87-862e-7d645117e83d">
