### PR TITLE
CMRARC-844: As an ARC curator, I would like to see some general improvements to the Discussion and Justification section

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1782,6 +1782,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.1)
+    nokogiri (1.16.4-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.4-x86_64-darwin)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -1948,6 +1950,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     thor (1.3.1)
     tilt (2.3.0)
@@ -1986,6 +1989,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-22
 
 DEPENDENCIES
@@ -2051,4 +2055,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.3.22
+   2.5.8

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -374,6 +374,7 @@
 
       .height_holder {
         height: 40px;
+        overflow: hidden;
       }
 
       .color_code_background {
@@ -531,6 +532,7 @@
   .discussion_td {
     vertical-align: top;
     max-height: 300px;
+    padding-bottom: 30px;
   }
 
   .discussion_holder {

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -233,8 +233,8 @@
     border-bottom: none;
 
     &__user-row {
-       border-left-color: $review-gray-dark;
-       border-top-color: $review-gray-dark;
+      border-left-color: $review-gray-dark;
+      border-top-color: $review-gray-dark;
     }
 
     &__script-row {
@@ -363,7 +363,7 @@
   }
 
   tr div {
-    max-height: fit-content;
+    max-height: 180px;
     min-height: 19px;
     overflow: auto;
   }

--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -347,7 +347,7 @@
   }
 
   tr div {
-    max-height:180px;
+    max-height: fit-content;
     min-height: 19px;
     overflow: auto;
   }
@@ -491,9 +491,6 @@
   }
 
   .new_discussion {
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-bottom-color:black;
 
     textarea {
       background-color:white;
@@ -502,6 +499,7 @@
       box-shadow: inset 2px 2px 2px 2px #dddddd;
       padding: 5px;
       box-sizing: border-box;
+      height: 150px;
     }
 
     textarea:disabled {
@@ -528,16 +526,16 @@
   }
 
   .discussion_comment {
+    padding-bottom: 2px;
+    margin-bottom: 5px;
 
     .discussion_title {
-      padding: 5px;
-
+      padding-bottom: 5px;
       font-size: 0.8em;
       font-weight: bold;
     }
 
     .discussion_text {
-      border-bottom: 1px solid black;
       display: flex;
       align-content: stretch;
       justify-content: center;
@@ -551,10 +549,12 @@
     justify-content: center;
     align-self: stretch;
     flex-grow: 1;
+    padding-bottom: 20px;
   }
   .discussion_text_label {
     display: flex;
     flex-grow: 1;
+    max-width: 73%;
   }
   .discussion_update_form {
     display: none;

--- a/app/views/reviews/_discussion_and_justification.html.erb
+++ b/app/views/reviews/_discussion_and_justification.html.erb
@@ -9,13 +9,14 @@
     <td class="discussion_td column_<%=title%>">
       <div class="discussion_holder">
         <div class="new_discussion">
-          <textarea oninput="activateSaveButton()" placeholder="New Comment..." name="discussion[<%= title %>]" form="field_form"></textarea>  
-        </div>
-
         <% messages = discussions.select { |discussion| discussion.column_name == title }.sort { |old_comment, new_comment| new_comment.date <=> old_comment.date } %>
         <% messages.each do |message| %>
           <%= render partial: 'edit_delete_comment', locals: { message: message } %>
         <% end %>
+        
+          <textarea oninput="activateSaveButton()" placeholder="New Comment..." name="discussion[<%= title %>]" form="field_form"></textarea>  
+        </div>
+
       </div>  
     </td>
   <% end %>

--- a/app/views/reviews/_edit_delete_comment.erb
+++ b/app/views/reviews/_edit_delete_comment.erb
@@ -27,7 +27,7 @@
       <!--Column 4: the update and delete icons-->
       <div id=<%= "icon-group" + getFormDiscussionId(message) %> class="discussion_update_icons">
         <i class="fa fa-edit fa-lg" style="font-size:16px" aria-hidden="true" onclick='toggle("<%=getFormDiscussionId(message)%>");toggle("<%="text" + getFormDiscussionId(message)%>"); toggle("<%="icon-group" + getFormDiscussionId(message)%>")'></i>
-        <%= link_to("javascript:submitDeleteForm(#{message.id.to_s})", data: {confirm: 'Delete discussion. Are you sure?'}) do %>
+        <%= link_to("javascript:submitDeleteForm(#{message.id.to_s})", data: {confirm: 'Delete discussion. Any unsaved changes will be lost. Are you sure?'}) do %>
           <i class="fa fa-remove fa-lg" style="font-size:16px; color: red" aria-hidden="true"></i>
         <% end %>
       </div>

--- a/app/views/reviews/_feedback_discussion.html.erb
+++ b/app/views/reviews/_feedback_discussion.html.erb
@@ -8,13 +8,14 @@
     <td class="discussion_td column_<%=title%>">
       <div class="discussion_holder">
         <div class="new_discussion">
-          <textarea oninput="activateSaveButton()" placeholder="New Comment..." name="feedback_discussion[<%= title %>]" form="field_form"></textarea>  
-        </div>
-
         <% messages = discussions.select { |discussion| discussion.column_name == title }.sort { |old_comment, new_comment| new_comment.date <=> old_comment.date } %>
         <% messages.each do |message| %>
           <%= render partial: 'edit_delete_comment', locals: { message: message } %>
         <% end %>
+        
+          <textarea oninput="activateSaveButton()" placeholder="New Comment..." name="feedback_discussion[<%= title %>]" form="field_form"></textarea>  
+        </div>
+
       </div>
     </td>
   <% end %>


### PR DESCRIPTION
Here are all the things this ticket addresses (from ticket AC)

1. Scrollbar is removed from Discussion and Justification section 
2. Making edit and delete icons always visible in the comment section
3. Users have ability to edit both comments and recommendations at the same time and save them _There were a few ideas about how best to do this. However the one we decided on was to change the delete alert to save "any unsaved changes will be lost"_
4. Moving comments up and/or flagging when a comment has been left _I opted to move comments up_
5. Excess scroll bars are removed from comment section 

Before: 
<img width="751" alt="Screenshot 2024-05-16 at 11 31 26 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/7f459333-a4ff-46a7-9fc7-11ab1dd06fd1">

<img width="758" alt="Screenshot 2024-05-16 at 11 32 55 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/922044aa-873d-4cda-bb11-fd971aa155bf">

<img width="611" alt="Screenshot 2024-05-16 at 11 31 41 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/19282022-7fca-4fee-a94f-b3cb905c2d96">

After: 
<img width="848" alt="Screenshot 2024-05-16 at 11 30 49 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/b9a6e4cb-ffda-4f14-8873-8bcf8d7348b2">

<img width="754" alt="Screenshot 2024-05-16 at 11 33 39 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/ccf907a3-4ae7-45c2-a093-406372d7e92d">

<img width="600" alt="Screenshot 2024-05-16 at 11 29 59 AM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/6297281a-aae5-4ab3-8853-eec4cc34d842">
