### PR TITLE
CMRARC-820: As a user, I can review a umm-c record where the sections appear similar to MMT.

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -661,7 +661,7 @@ class Record < ApplicationRecord
     end
   end
 
-  # Returns should return a list where each entry is a (title,[title_list])
+  # Should return a list where each entry is a (title,[title_list])
   def mmt_sections
     section_list = []
 

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -626,6 +626,10 @@ class Record < ApplicationRecord
 
   #should return a list where each entry is a (title,[title_list])
   def sections
+    if format == 'umm_json' and recordable_type == "Collection"
+      return mmt_sections
+    end
+
     section_list = []
 
     get_section_titles.each do |title|
@@ -655,6 +659,49 @@ class Record < ApplicationRecord
       end
       section_list
     end
+  end
+
+  # Returns should return a list where each entry is a (title,[title_list])
+  def mmt_sections
+    section_list = []
+
+    path = File.join(Rails.root,"/data/ummc_section_titles.json")
+    json = JSON.load(File.read(path))
+    field_list = []
+    map = {}
+    json.each do |obj|
+      display_name = obj["displayName"]
+      field_list << display_name
+      map[display_name] = obj["properties"]
+    end
+
+    field_list.each do |title|
+      section = self.get_mmt_section(title, map)
+      if section[0][1].count > 0
+        section_list += section
+      end
+    end
+
+    used_titles = (section_list.map {|section| section[1]}).flatten
+    all_titles = self.sorted_record_datas.map { |data| data.column_name }
+
+    others = [["Other", all_titles.select {|title| !used_titles.include? title }]]
+
+    section_list + others
+  end
+
+  def get_mmt_section(section_name, map)
+    section_list = []
+
+    all_titles = self.sorted_record_datas.map { |data| data.column_name }
+    sections = map[section_name]
+    sections.each do |sub_section_name|
+      one_section = all_titles.select { |title| title.match(/^#{sub_section_name}/) }
+      if one_section.any?
+        section_list.push(one_section)
+      end
+    end
+    [[section_name, section_list.flatten]]
   end
 
   def color_codes

--- a/app/views/records/_collection_section_details.html.erb
+++ b/app/views/records/_collection_section_details.html.erb
@@ -1,5 +1,5 @@
 <article class="section_display flex_item">
-  <button class="section_button" onclick="location.href='<%= review_path(id: params["id"], section_index: index_count) %>';">
+  <button data-testid="records--show__<%=section[0]%>" class="section_button" onclick="location.href='<%= review_path(id: params["id"], section_index: index_count) %>';">
   <%= space_digits(section[0]) %>
   <!-- arrow to review section -->
   <div class="eui-icon eui-fa-arrow-circle-right"></div>

--- a/data/ummc_section_titles.json
+++ b/data/ummc_section_titles.json
@@ -1,0 +1,102 @@
+[
+  {
+    "displayName": "Collection Information",
+    "properties": [
+      "ShortName",
+      "Version",
+      "VersionDescription",
+      "EntryTitle",
+      "DOI",
+      "AssociatedDOIs",
+      "Abstract",
+      "Purpose",
+      "DataLanguage"
+    ]
+  },
+  {
+    "displayName": "Data Identification",
+    "properties": [
+      "DataDates",
+      "CollectionDataType",
+      "StandardProduct",
+      "ProcessingLevel",
+      "CollectionProgress",
+      "Quality",
+      "UseConstraints",
+      "AccessConstraints",
+      "MetadataAssociations",
+      "PublicationReferences"
+    ]
+  },
+  {
+    "displayName": "Related URLs",
+    "properties": [
+      "RelatedUrls"
+    ]
+  },
+  {
+    "displayName": "Descriptive Keywords",
+    "properties": [
+      "ScienceKeywords",
+      "AncillaryKeywords",
+      "AdditionalAttributes"
+    ]
+  },
+  {
+    "displayName": "Acquisition Information",
+    "properties": [
+      "Platforms",
+      "Projects"
+    ]
+  },
+  {
+    "displayName": "Temporal Information",
+    "properties": [
+      "TemporalExtents",
+      "TemporalKeywords",
+      "PaleoTemporalCoverages"
+    ]
+  },
+  {
+    "displayName": "Spatial Information",
+    "properties": [
+      "SpatialExtent",
+      "SpatialInformation",
+      "TilingIdentificationSystems",
+      "LocationKeywords"
+    ]
+  },
+  {
+    "displayName": "Data Centers",
+    "properties": [
+      "DataCenters"
+    ]
+  },
+  {
+    "displayName": "Data Contacts",
+    "properties": [
+      "ContactPersons",
+      "ContactGroups"
+    ]
+  },
+  {
+    "displayName": "Collection Citations",
+    "properties": [
+      "CollectionCitation"
+    ]
+  },
+  {
+    "displayName": "Metadata Information",
+    "properties": [
+      "MetadataLanguage",
+      "MetadataDates"
+    ]
+  },
+  {
+    "displayName": "Archive And Distribution Information",
+    "properties": [
+      "ArchiveAndDistributionInformation",
+      "DirectDistributionInformation"
+    ]
+  }
+]

--- a/test/features/mmt_bubbles_test.rb
+++ b/test/features/mmt_bubbles_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+require 'capybara/rails'
+require 'capybara/minitest'
+Dir[Rails.root.join('test/**/*.rb')].each {|f| require f}
+
+class MmtBubblesTest < SystemTestCase
+  include Helpers::UserHelpers
+
+  before do
+    OmniAuth.config.test_mode = true
+    mock_login(role: 'arc_curator')
+
+    stub_request(:get, "#{Cmr.get_cmr_base_url}/search/granules.echo10?concept_id=G309210-GHRC")
+      .with(
+        headers: {'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Accept' => '*/*'}
+      )
+      .to_return(status: 200, body: '<?xml version="1.0" encoding="UTF-8"?><results><hits>0</hits><took>32</took></results>', headers: {})
+  end
+
+  describe 'ingesting a umm-c collection record' do
+    # this test will mock a user click on a bubble and then navigate to the correct
+    # sub-section it indicates in the review table.
+    it 'shows mmt section bubbles' do
+      visit '/home'
+
+      within '#in_arc_review' do
+        all('#record_id_')[2].click  # Selects the third checkbox in "in arc review records" which is a umm-c record
+        find('div > div.navigate-buttons > input.selectButton').click # Clicks the See Review Details button
+      end
+      within '#collection_revision_1' do
+        click_on "See Collection Review Details"
+      end
+      assert_selector("[data-testid='records--show__Data Identification']")
+      find("[data-testid='records--show__Data Identification']").click
+      within "#review_table" do
+        assert_selector('#column_Quality')
+      end
+    end
+  end
+end

--- a/test/fixtures/record_data.yml
+++ b/test/fixtures/record_data.yml
@@ -345,3 +345,16 @@ granule_red_longname:
   opinion: false
   flag: []
   recommendation: "ok"
+
+iso_collection_1_quality:
+  id: 42
+  record_id: 42
+  column_name: "Quality"
+  value: "Test Iso Collection 1 Quality"
+  last_updated: null
+  color: "green"
+  script_comment: "ok"
+  opinion: false
+  flag: [ ]
+  recommendation: "ok"
+


### PR DESCRIPTION

# Overview

### What is the feature?

Reviewing a umm-c record should show sections similar to MMT.

### What is the Solution?

Added the same configuration file that MMT uses for sections and fields to include for each section.   Dashboard now uses this to drive the UI for section/field organization.

### What areas of the application does this impact?

Ingest of umm-c records.

# Testing

### Reproduction steps

View any umm-c record in dashboard, you should see the section/field lists have changed, they now match what is in MMT.

### Attachments
![Screenshot 2024-05-21 at 5 20 42 PM](https://github.com/nasa/cmr-metadata-review/assets/22039502/83b48475-7e3f-4f9c-ad20-5d8389992ce3)

# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
