### PR TITLE
CMRARC-865: As an ARC Curator, I would like to see three new dashboard bugs fixed

### DIFF
--- a/app/assets/stylesheets/pages/_reviews.scss
+++ b/app/assets/stylesheets/pages/_reviews.scss
@@ -253,13 +253,10 @@
     min-width: 220px;
     position: relative;
     padding-right: 25px;
-    height: 50px;
-    position: relative;
   }
 
   .title_column::after {
     display: block;
-    content: '';
     position: absolute;
     inset: 0;
     background-color: transparent;
@@ -268,6 +265,7 @@
 
   .title_column.highlighted::after {
     background-color: rgba(255, 255, 0, 0.5);
+    content: '';
     transition: background-color 1s;
   }
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -189,6 +189,42 @@
 
 
     <script type="text/javascript">
+      //sets all of the flag colors on first/following page loads and updates
+      function update_color_backgrounds() {
+        //hidden select inputs
+        var color_selects = document.getElementsByClassName("color_code_select");
+        //full td cell
+        var color_cells = document.getElementsByClassName("color_code_cell");
+        //the div containing the color selecting icons
+        var color_button_sets = document.getElementsByClassName("color_code_background");
+        //the divs containing the x out option to remove a selected color
+        var color_cancels = document.getElementsByClassName("color_cancel_selection");
+
+        var counter = 0;
+        //iterating over all the hidden color select inputs
+        while (counter < color_selects.length) {
+          var color = color_selects[counter].value
+          //Removing all BG colors from the cell
+          <% ["color_green", "color_yellow", "color_red", "color_blue", "color_gray"].each do |color_class| %>
+          color_cells[counter].classList.remove("<%=color_class%>");
+          <% end %>
+          //adding the class that corresponds to the color selected in the select input
+          color_cells[counter].classList.add("color_" + color.toString());
+          //if no color selected, show the set of color icons to click
+          if (color == "") {
+            color_button_sets[counter].style.display = "flex";
+            color_cancels[counter].style.display = "none";
+            //if color is selected, hide color icons, and show the x out button to remove color selection
+          } else {
+            color_button_sets[counter].style.display = "none";
+            color_cancels[counter].style.display = "block";
+          }
+          counter = counter + 1;
+        }
+      }
+      
+      update_color_backgrounds()
+
       //Users who are directed to the reviews page from a bubble click redirect to section they clicked on
       var storedTargetField = sessionStorage.getItem('targetField')
       var escapedTargetField = $.escapeSelector(storedTargetField)
@@ -206,7 +242,6 @@
     //Allows users to click on bubble up top and be auto-directed to the column it's referring to
       function bubbleFocus(targetName) {
         var escapedTargetName = $.escapeSelector(targetName)
-        console.log("🚀 ~ bubbleFocus ~ escapedTargetName:", escapedTargetName)
         var associatedTargetElement = $('#column_' + escapedTargetName)[0]
         
         associatedTargetElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })
@@ -285,42 +320,6 @@
         }, false);
       })();
 
-
-      //sets all of the flag colors on page loads and updates
-      function update_color_backgrounds() {
-        //hidden select inputs
-        var color_selects = document.getElementsByClassName("color_code_select");
-        //full td cell
-        var color_cells = document.getElementsByClassName("color_code_cell");
-        //the div containing the color selecting icons
-        var color_button_sets = document.getElementsByClassName("color_code_background");
-        //the divs containing the x out option to remove a selected color
-        var color_cancels = document.getElementsByClassName("color_cancel_selection");
-
-        var counter = 0;
-        //iterating over all the hidden color select inputs
-        while (counter < color_selects.length) {
-          var color = color_selects[counter].value
-          //Removing all BG colors from the cell
-          <% ["color_green", "color_yellow", "color_red", "color_blue", "color_gray"].each do |color_class| %>
-          color_cells[counter].classList.remove("<%=color_class%>");
-          <% end %>
-          //adding the class that corresponds to the color selected in the select input
-          color_cells[counter].classList.add("color_" + color.toString());
-          //if no color selected, show the set of color icons to click
-          if (color == "") {
-            color_button_sets[counter].style.display = "flex";
-            color_cancels[counter].style.display = "none";
-            //if color is selected, hide color icons, and show the x out button to remove color selection
-          } else {
-            color_button_sets[counter].style.display = "none";
-            color_cancels[counter].style.display = "block";
-          }
-          counter = counter + 1;
-        }
-      }
-
-      update_color_backgrounds();
     </script>
 
 

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -230,12 +230,14 @@
       var escapedTargetField = $.escapeSelector(storedTargetField)
       var storedTargetFieldElement = $('#column_' + escapedTargetField)[0]
 
-      storedTargetFieldElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })
-      storedTargetFieldElement.classList.add("highlighted")
-
-      setTimeout(function() {
-        storedTargetFieldElement.classList.remove("highlighted");
-      }, 2000);
+      if (storedTargetFieldElement) {
+        storedTargetFieldElement.scrollIntoView({ behavior: 'smooth', inline: 'center' })
+        storedTargetFieldElement.classList.add("highlighted")
+  
+        setTimeout(function() {
+          storedTargetFieldElement.classList.remove("highlighted");
+        }, 2000);
+      }
 
       sessionStorage.setItem('targetField', '')
       

--- a/test/features/bubble_focus_test.rb
+++ b/test/features/bubble_focus_test.rb
@@ -35,6 +35,7 @@ class BubbleFocusTest < SystemTestCase
         end
         within "#review_table" do
           assert_selector('#column_LongName.highlighted')
+          assert_selector('td.color_code_cell.column_LongName.color_green')
         end
         within "#bubble_title" do
           find('#bubble_ShortName', wait: 10).click


### PR DESCRIPTION
# Overview

### What is the feature?

Three issues:
1. The width-resize buttons weren't working
2. update_color_backgrounds() wasn't executing on initial page load
3. Cannot hover over the * to see the acceptable criteria

### What is the Solution?

1. Ended up being a line of .scss called 'content'. Just moved it to another area. Now you can resize the column widths and see the astrick hover-over text. 
2. update_color_backgrounds was too far down the script. It needed to render before other logic came in so I just bumped it up. 

### What areas of the application does this impact?

_reviews.scss
the review table when you select a collection >> See Review Detail >> See Collection Review Detail

# Testing

### Reproduction steps

- **Environment for testing: Local
- **Collection to test with: Whichever you'd like

1. Pull down this branch and run rails s
2. Ingest a collection for review if you don't have one
3. Click through to select a collection >> See Review Detail >> See Collection Review Detail
4. You should now be able to re-adjust the column widths and hover over * to see Acceptance Criteria. 
5. If the bubbles were previously colored in, then the color code bar should look like below upon page load (previously it would only block out the cell like that if you clicked on another cell within that row). 

<img width="1312" alt="Screenshot 2024-06-10 at 5 11 20 PM" src="https://github.com/nasa/cmr-metadata-review/assets/135638667/a1060af7-c847-470c-869a-272e4d844e46">
### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ x] I have added automated tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
