### PR TITLE
CMRARC-866: Adding rexml for SIT issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,7 @@ gem 'omniauth-rails_csrf_protection'
 gem 'figaro'
 gem 'rails-controller-testing'
 gem 'actionpack', '7.0.8.4'
+gem 'rexml'
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2034,6 +2034,7 @@ DEPENDENCIES
   rails-erd
   rdoc
   react-rails (= 2.6)
+  rexml
   rspec-rails
   ruby-progressbar
   rubyXL


### PR DESCRIPTION
# Overview

### What is the feature?

SIT is no longer working. While everything still works locally, it appears that sit is unable to process rexml as per splunk record here:

I, [2024-06-18T17:22:06.274471 #2433550] INFO -- : Completed 500 Internal Server Error in 852ms (ActiveRecord: 9.8ms | Allocations: 8258)
F, [2024-06-18T17:22:06.274979 #2433550] FATAL -- : LoadError (cannot load such file -- rexml/document): app/models/cmr.rb:575:in `collection_search' app/controllers/collections_controller.rb:84:in `search' app/middleware/middleware_healthcheck.rb:14:in `call'

### What is the Solution?

Going to manually install gem 'rexml'

### What areas of the application does this impact?

gemfile

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. As far as I know, there is no way to test that this works until this fix is up in SIT. 

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
