### PR TITLE
CMRARC-882: Fixing high vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1820,7 +1820,7 @@ GEM
       puma (>= 5.0)
       rack
     racc (1.8.1)
-    rack (2.2.9)
+    rack (2.2.13)
     rack-protection (3.2.0)
       base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
@@ -2056,4 +2056,4 @@ RUBY VERSION
    ruby 3.0.6p216
 
 BUNDLED WITH
-   2.3.22
+   2.5.8

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer role="contentinfo">
   <ul class="footer-links">
     <li><span class="version badge eui-badge--md">v <%= Rails.configuration.version %>|pyQuARC <%= pyquarc_version() %></span></li>
-    <li>NASA Official: Stephen Berrick</li>
+    <li>NASA Official: Doug Newman</li>
     <li><a href="http://www.nasa.gov/FOIA/index.html">FOIA</a></li>
     <li><a href="http://www.nasa.gov/about/highlights/HP_Privacy.html">NASA Privacy Policy</a></li>
     <li><a href="http://www.usa.gov/">USA.gov</a></li>


### PR DESCRIPTION
# Overview

### What is the feature?

CMR-Dashboard vulnerabilities checked on March 17, 2025

https://github.com/nasa/cmr-metadata-review/security/dependabot
1 high vulnerability - fix available
#176 https://github.com/nasa/cmr-metadata-review/security/dependabot/176

### What is the Solution?

Name: rack
Version: 2.2.9
CVE: CVE-2025-27610
GHSA: GHSA-7wqh-767x-r66v
Criticality: High
URL: https://github.com/rack/rack/security/advisories/GHSA-7wqh-767x-r66v
Title: Local File Inclusion in Rack::Static
Solution: upgrade to '~> 2.2.13', '~> 3.0.14', '>= 3.1.12'

^^ the slash-through above is just a weird github formatting thing. Version 2.2.13 is recommended for Rails versions 7.x.x.

Ran
$ gem install rack -v 2.2.13

### What areas of the application does this impact?

gemfile

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Sanity check to make sure local environment still works
2. Step 2...

### Attachments

Please include relevant screenshots or files that would be helpful in reviewing and verifying this change.

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
