### PR TITLE
CMRARC-789: Fixing duplicate field in CMR Dashboard

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -696,7 +696,7 @@ class Record < ApplicationRecord
     all_titles = self.sorted_record_datas.map { |data| data.column_name }
     sections = map[section_name]
     sections.each do |sub_section_name|
-      one_section = all_titles.select { |title| title.match(/^#{sub_section_name}/) }
+      one_section = all_titles.select { |title| title.match(/^#{sub_section_name}$/) }
       if one_section.any?
         section_list.push(one_section)
       end

--- a/test/features/perform_sanity_checks_on_reviews_test.rb
+++ b/test/features/perform_sanity_checks_on_reviews_test.rb
@@ -174,7 +174,7 @@ class PerformsSanityChecksOnReviewsTest < SystemTestCase
       see_collection_review_details('#in_arc_review', 1)
       see_collection_revision_details(8)
       click_button 'Collection Info'
-      expect(page).to have_content("VersionDescription", count: 2)
+      page.must_have_content("VersionDescription", count: 2)
     end
   end
 end

--- a/test/features/perform_sanity_checks_on_reviews_test.rb
+++ b/test/features/perform_sanity_checks_on_reviews_test.rb
@@ -173,7 +173,6 @@ class PerformsSanityChecksOnReviewsTest < SystemTestCase
       # Select First Collection in In Arc Review
       see_collection_review_details('#in_arc_review', 1)
       see_collection_revision_details(8)
-      click_button 'MARK AS DONE'
       click_button 'Collection Info'
       expect(page).to have_content("VersionDescription", count: 2)
     end

--- a/test/features/perform_sanity_checks_on_reviews_test.rb
+++ b/test/features/perform_sanity_checks_on_reviews_test.rb
@@ -162,6 +162,22 @@ class PerformsSanityChecksOnReviewsTest < SystemTestCase
       assert_no_css '#done_button'
     end
   end
+
+  describe 'viewing the Collection Info, only one VersionDescription column is present.' do
+    before do
+      mock_login(role: 'arc_curator')
+      visit '/home'
+    end
+
+    it 'verify only one VersionDescription appears' do
+      # Select First Collection in In Arc Review
+      see_collection_review_details('#in_arc_review', 1)
+      see_collection_revision_details(8)
+      click_button 'MARK AS DONE'
+      click_button 'Collection Info'
+      expect(page).to have_content("VersionDescription", count: 2)
+    end
+  end
 end
 
 

--- a/test/features/perform_sanity_checks_on_reviews_test.rb
+++ b/test/features/perform_sanity_checks_on_reviews_test.rb
@@ -162,21 +162,6 @@ class PerformsSanityChecksOnReviewsTest < SystemTestCase
       assert_no_css '#done_button'
     end
   end
-
-  describe 'viewing the Collection Info, only one VersionDescription column is present.' do
-    before do
-      mock_login(role: 'arc_curator')
-      visit '/home'
-    end
-
-    it 'verify only one VersionDescription appears' do
-      # Select First Collection in In Arc Review
-      see_collection_review_details('#in_arc_review', 1)
-      see_collection_revision_details(8)
-      click_button 'Collection Info'
-      page.must_have_content("VersionDescription", count: 2)
-    end
-  end
 end
 
 


### PR DESCRIPTION
# Overview

### What is the feature?

CMR Dashboard has a duplicate VersionDescription when viewing collection info

### What is the Solution?

Corrected the regex match to match on ending as well. This allows only one column returned at a time.

### What areas of the application does this impact?

CMR Dashboard

# Testing

### Reproduction steps

Login to CMR Dashboard.

Select a record in review. Click on "See Review Detail"

Click "See Collection Review Details"

Click on "Collection Information"

Make sure only 1 VersionDescription column shows up

### Attachments
This shows the issue
<img width="1335" height="526" alt="Screenshot 2025-07-10 at 9 25 31 AM" src="https://github.com/user-attachments/assets/08756d0a-42ce-480a-a750-cc1030eb0d6d" />
This shows the fix
<img width="1666" height="581" alt="Screenshot 2025-07-10 at 9 23 57 AM" src="https://github.com/user-attachments/assets/6bfc9171-04e4-45ed-a901-d002d73045f6" />

# Checklist

- [ ] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
